### PR TITLE
Fixing misspelling of parametrized -> parameterized

### DIFF
--- a/nondex-core/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java
+++ b/nondex-core/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java
@@ -14,24 +14,24 @@ public abstract class AbstractCollectionTest<T> {
     
     protected void parameterized(T ds, Object derived, String str) {
         switch (ControlNondeterminism.getConfiguration().mode) {
-        case FULL: 
-            String s = derived.toString();
-            assertNotEquals("FULL is improperly running", str, s);
-            assertEqualstUnordered("Does not match Permutation", str, s);
-            break;
-        case ID:
-            assertEquals("ID should return the same when collection is unchanged", str, derived.toString());
-            this.addRemoveDS(ds);
-            assertNotEquals("ID should return different when collection is modified", str, derived.toString());
-            break;
-        case EQ:
-            assertEquals("EQ is improperly running", str, derived.toString());
-            this.addRemoveDS(ds);
-            assertEquals("EQ should return the same for two equal collections", str, derived.toString());
-            break;
-        case ONE:
-            assertEquals("ONE is improperly running", str, derived.toString());
-            break;
+            case FULL: 
+                String s = derived.toString();
+                assertNotEquals("FULL is improperly running", str, s);
+                assertEqualstUnordered("Does not match Permutation", str, s);
+                break;
+            case ID:
+                assertEquals("ID should return the same when collection is unchanged", str, derived.toString());
+                this.addRemoveDS(ds);
+                assertNotEquals("ID should return different when collection is modified", str, derived.toString());
+                break;
+            case EQ:
+                assertEquals("EQ is improperly running", str, derived.toString());
+                this.addRemoveDS(ds);
+                assertEquals("EQ should return the same for two equal collections", str, derived.toString());
+                break;
+            case ONE:
+                assertEquals("ONE is improperly running", str, derived.toString());
+                break;
         }
     }
     

--- a/nondex-core/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java
+++ b/nondex-core/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java
@@ -17,7 +17,7 @@ public abstract class AbstractCollectionTest<T> {
             case FULL: 
                 String s = derived.toString();
                 assertNotEquals("FULL is improperly running", str, s);
-                assertEqualstUnordered("Does not match Permutation", str, s);
+                assertEqualstUnordered("Does not match permutation", str, s);
                 break;
             case ID:
                 assertEquals("ID should return the same when collection is unchanged", str, derived.toString());
@@ -37,7 +37,7 @@ public abstract class AbstractCollectionTest<T> {
     
     protected void assertEqualstUnordered(String msg, String expected, String actual) {
         assertEquals(msg + ": " + expected + " =/= " + actual, expected.length(), actual.length());
-        expected = expected.substring(1,expected.length() - 1);
+        expected = expected.substring(1, expected.length() - 1);
         String[] elems = expected.split(",");
         // TODO(gyori): fix and make this more robust. It does not check duplicates, substrings, etc.
         for (int i = 0; i < elems.length; i++) {

--- a/nondex-core/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java
+++ b/nondex-core/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java
@@ -12,7 +12,7 @@ public abstract class AbstractCollectionTest<T> {
     abstract protected T createResizedDS(int start, int maxSize);    
     abstract protected T addRemoveDS(T ds);
     
-    protected void parametrized(T ds, Object derived, String str) {
+    protected void parameterized(T ds, Object derived, String str) {
         switch (ControlNondeterminism.getConfiguration().mode) {
         case FULL: 
             String s = derived.toString();

--- a/nondex-core/src/test/java/edu/illinois/nondex/core/ConcurrentHashMapTest.java
+++ b/nondex-core/src/test/java/edu/illinois/nondex/core/ConcurrentHashMapTest.java
@@ -75,7 +75,7 @@ public class ConcurrentHashMapTest extends AbstractCollectionTest<ConcurrentHash
         ConcurrentHashMap<Integer, Integer> map = createResizedDS();
         Set<Integer> keySet = map.keySet();
 
-        this.parametrized(map, keySet, keySet.toString());
+        this.parameterized(map, keySet, keySet.toString());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class ConcurrentHashMapTest extends AbstractCollectionTest<ConcurrentHash
     }
 
     @Test
-    public void testValuesParametrized() {
+    public void testValuesParameterized() {
         ConcurrentHashMap<Integer, Integer> map = createResizedDS();
         Collection<Integer> values = map.values();
 
@@ -95,7 +95,7 @@ public class ConcurrentHashMapTest extends AbstractCollectionTest<ConcurrentHash
         assertEqualstUnordered("The strings are not a permutation of each other", "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}", values.toString());
 
         String str = values.toString();
-        parametrized(map, values, str);
+        parameterized(map, values, str);
     }
 
     @Test
@@ -108,12 +108,12 @@ public class ConcurrentHashMapTest extends AbstractCollectionTest<ConcurrentHash
     }
 
     @Test
-    public void testEntrySetParametrized() {
+    public void testEntrySetParameterized() {
         ConcurrentHashMap<Integer, Integer> map = createResizedDS();
         Set<Entry<Integer, Integer>> entrySet = map.entrySet();
 
         String str = entrySet.toString();
-        parametrized(map, entrySet, str);
+        parameterized(map, entrySet, str);
     }
 
     @Test

--- a/nondex-core/src/test/java/edu/illinois/nondex/core/HashMapTest.java
+++ b/nondex-core/src/test/java/edu/illinois/nondex/core/HashMapTest.java
@@ -76,7 +76,7 @@ public class HashMapTest extends AbstractCollectionTest<Map<Integer, Integer>>{
         Map<Integer, Integer> map = createResizedDS();
         Set<Integer> keySet = map.keySet();
 
-        this.parametrized(map, keySet, keySet.toString());
+        this.parameterized(map, keySet, keySet.toString());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class HashMapTest extends AbstractCollectionTest<Map<Integer, Integer>>{
         assertEqualstUnordered("The strings are not a permuation of each other", "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}", values.toString());
 
         String str = values.toString();
-        parametrized(map, values, str);
+        parameterized(map, values, str);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class HashMapTest extends AbstractCollectionTest<Map<Integer, Integer>>{
         Set<Entry<Integer, Integer>> entrySet = map.entrySet();
 
         String str = entrySet.toString();
-        parametrized(map, entrySet, str);
+        parameterized(map, entrySet, str);
     }
 
 }

--- a/nondex-core/src/test/java/edu/illinois/nondex/core/HashSetTest.java
+++ b/nondex-core/src/test/java/edu/illinois/nondex/core/HashSetTest.java
@@ -55,6 +55,6 @@ public class HashSetTest extends AbstractCollectionTest<Set<Integer>>{
     @Test
     public void testHashSetParametrized() {
         Set<Integer> s = createResizedDS(0, 100000); 
-        this.parametrized(s, s, s.toString());
+        this.parameterized(s, s, s.toString());
     }
 }


### PR DESCRIPTION
I noticed that there seem to be some misspellings in the test names in these test classes along with the same misspelling in the helper method, and so this pull request simply addresses those misspellings.