### PR TITLE
Writing stack trace to debug file

### DIFF
--- a/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java
@@ -162,6 +162,10 @@ public class Configuration {
         return Paths.get(this.nondexDir, this.executionId, ConfigurationDefaults.INVOCATIONS_FILE);
     }
 
+    public Path getDebugPath() {
+        return Paths.get(this.nondexDir, this.executionId, ConfigurationDefaults.DEBUG_FILE);
+    }
+
     public Path getConfigPath() {
         return Paths.get(this.nondexDir, this.executionId, ConfigurationDefaults.CONFIGURATION_FILE);
     }

--- a/nondex-common/src/main/java/edu/illinois/nondex/common/ConfigurationDefaults.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/ConfigurationDefaults.java
@@ -77,6 +77,7 @@ public class ConfigurationDefaults {
     public static final String INSTRUMENTATION_JAR = "nondex-instr.jar";
     public static final String FAILURES_FILE = "failures";
     public static final String INVOCATIONS_FILE = "invocations";
+    public static final String DEBUG_FILE = "debug";
     public static final String CONFIGURATION_FILE = "config";
 
     public static final int SEED_FACTOR = 0xA1e4;


### PR DESCRIPTION
This pull request changes the logic to output the stack trace when a single choice point is found to be the issue into a new debug file. Note that writing to file invokes Nondex, so special care is in place to make sure to prevent infinite calls to file writing, but may schew the SHUFFLE and COUNT values, but may not be an issue.