### PR TITLE
fixed NPE when some file is not in the jar

### DIFF
--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
@@ -224,14 +224,19 @@ public final class Instrumenter {
         Iterator<String> it = toShuffle.iterator();
         while (it.hasNext()) {
             String cl = it.next();
+
             ZipEntry entry = rt.getEntry(cl);
-            if (entry != null) {
-                InputStream clInputStream = rt.getInputStream(entry);
+            if (entry == null) {
+                continue;
             }
+            InputStream clInputStream = rt.getInputStream(entry);
+
             entry = outJarZipFile.getEntry(cl + ".md5");
-            if (entry != null) {
-                InputStream md5InputStream = outJarZipFile.getInputStream(entry);
+            if (entry == null) {
+                continue;
             }
+            InputStream md5InputStream = outJarZipFile.getInputStream(entry);
+
             if (Arrays.equals(this.toMd5(clInputStream), this.readAllBytes(md5InputStream))) {
                 it.remove();
                 toCopy.add(cl);

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
@@ -224,8 +224,14 @@ public final class Instrumenter {
         Iterator<String> it = toShuffle.iterator();
         while (it.hasNext()) {
             String cl = it.next();
-            InputStream clInputStream = rt.getInputStream(rt.getEntry(cl));
-            InputStream md5InputStream = outJarZipFile.getInputStream(outJarZipFile.getEntry(cl + ".md5"));
+            ZipEntry entry = rt.getEntry(cl);
+            if (entry != null) {
+                InputStream clInputStream = rt.getInputStream(entry);
+            }
+            entry = outJarZipFile.getEntry(cl + ".md5");
+            if (entry != null) {
+                InputStream md5InputStream = outJarZipFile.getInputStream(entry);
+            }
             if (Arrays.equals(this.toMd5(clInputStream), this.readAllBytes(md5InputStream))) {
                 it.remove();
                 toCopy.add(cl);


### PR DESCRIPTION
This actually happened when running on an old jar without the .md5 files in it. It could happen also when a jar does not have all the class files in it.