### PR TITLE
added a new Mojo to clean artifacts

### DIFF
--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
@@ -224,8 +224,19 @@ public final class Instrumenter {
         Iterator<String> it = toShuffle.iterator();
         while (it.hasNext()) {
             String cl = it.next();
-            InputStream clInputStream = rt.getInputStream(rt.getEntry(cl));
-            InputStream md5InputStream = outJarZipFile.getInputStream(outJarZipFile.getEntry(cl + ".md5"));
+
+            ZipEntry entry = rt.getEntry(cl);
+            if (entry == null) {
+                continue;
+            }
+            InputStream clInputStream = rt.getInputStream(entry);
+
+            entry = outJarZipFile.getEntry(cl + ".md5");
+            if (entry == null) {
+                continue;
+            }
+            InputStream md5InputStream = outJarZipFile.getInputStream(entry);
+
             if (Arrays.equals(this.toMd5(clInputStream), this.readAllBytes(md5InputStream))) {
                 it.remove();
                 toCopy.add(cl);

--- a/nondex-maven-plugin/src/it/clean-it/invoker.properties
+++ b/nondex-maven-plugin/src/it/clean-it/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = nondex:nondex nondex:clean

--- a/nondex-maven-plugin/src/it/clean-it/pom.xml
+++ b/nondex-maven-plugin/src/it/clean-it/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>nondex.plugin.it</groupId>
+  <artifactId>simple-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying the basic use of clean Mojo.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+      <dependency>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+      </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+    
+</project>

--- a/nondex-maven-plugin/src/it/clean-it/src/test/java/edu/illinois/nondex/it/AppTest.java
+++ b/nondex-maven-plugin/src/it/clean-it/src/test/java/edu/illinois/nondex/it/AppTest.java
@@ -1,0 +1,39 @@
+/*
+The MIT License (MIT)
+Copyright (c) 2015 Alex Gyori
+Copyright (c) 2015 Owolabi Legunsen
+Copyright (c) 2015 Darko Marinov
+Copyright (c) 2015 August Shi
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package edu.illinois.nondex.it;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class AppTest
+{
+    @Test
+    public void testHashSet() {
+        assertTrue(true);
+    }
+}

--- a/nondex-maven-plugin/src/it/clean-it/verify.groovy
+++ b/nondex-maven-plugin/src/it/clean-it/verify.groovy
@@ -1,0 +1,3 @@
+File nondexDirectory = new File( basedir, ".nondex" );
+
+assert ! nondexDirectory.exists();

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanMojo.java
@@ -1,0 +1,71 @@
+/*
+The MIT License (MIT)
+Copyright (c) 2015 Alex Gyori
+Copyright (c) 2015 Owolabi Legunsen
+Copyright (c) 2015 Darko Marinov
+Copyright (c) 2015 August Shi
+
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package edu.illinois.nondex.plugin;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import edu.illinois.nondex.common.ConfigurationDefaults;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Removes NonDex plugin artifacts (i.e. the ".nondex" directories in each
+ * module root) as well as the directory containig the NonDex jar.
+ */
+@Mojo(name = "clean", requiresDirectInvocation = true)
+public class CleanMojo extends AbstractNondexMojo {
+
+    public void execute() throws MojoExecutionException {
+        Path nondexArtifactsPath = Paths.get(this.baseDir.getAbsolutePath(), ConfigurationDefaults.DEFAULT_NONDEX_DIR);
+        Path nondexJarPath = Paths.get(this.baseDir.getAbsolutePath(), ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR);
+
+        File artifactsDir = nondexArtifactsPath.toFile();
+        File nondexJarDir = nondexJarPath.toFile();
+
+        if (nondexJarDir.exists()) {
+            delete(nondexJarDir);
+        }
+
+        if (artifactsDir.exists()) {
+            delete(artifactsDir);
+        }
+    }
+
+    public void delete(File file) {
+        if (file.isDirectory()) {
+            for (File childFile : file.listFiles()) {
+                delete(childFile);
+            }
+        }
+        file.delete();
+    }
+}

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanMojo.java
@@ -39,20 +39,23 @@ import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Removes NonDex plugin artifacts (i.e. the ".nondex" directories in each
- * module root) as well as the directory containig the NonDex jar.
+ * module root) as well as the NonDex jar.
  */
 @Mojo(name = "clean", requiresDirectInvocation = true)
 public class CleanMojo extends AbstractNondexMojo {
 
     public void execute() throws MojoExecutionException {
-        Path nondexArtifactsPath = Paths.get(this.baseDir.getAbsolutePath(), ConfigurationDefaults.DEFAULT_NONDEX_DIR);
-        Path nondexJarPath = Paths.get(this.baseDir.getAbsolutePath(), ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR);
+        Path nondexArtifactsPath = Paths.get(this.baseDir.getAbsolutePath(),
+                ConfigurationDefaults.DEFAULT_NONDEX_DIR);
+        Path nondexJarPath = Paths.get(this.baseDir.getAbsolutePath(),
+                ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR,
+                ConfigurationDefaults.INSTRUMENTATION_JAR);
 
         File artifactsDir = nondexArtifactsPath.toFile();
-        File nondexJarDir = nondexJarPath.toFile();
+        File nondexJar = nondexJarPath.toFile();
 
-        if (nondexJarDir.exists()) {
-            delete(nondexJarDir);
+        if (nondexJar.exists()) {
+            delete(nondexJar);
         }
 
         if (artifactsDir.exists()) {


### PR DESCRIPTION
After this is merged, users will be able to clean NonDex artifacts by invoking `mvn nondex:clean`.

@august782, @alexgyori please review.