### PR TITLE
Update Debug Task

### DIFF
--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
@@ -75,8 +75,6 @@ public class DebugMojo extends AbstractNondexMojo {
             DebugTask debugging = new DebugTask(test, this.surefire, this.originalArgLine,
                     this.mavenProject, this.mavenSession, this.pluginManager, this.testsFailing.get(test));
             String repro = debugging.debug();
-            Logger.getGlobal().log(Level.SEVERE, "REPRO: mvn nondex:nondex " + repro);
-
             testToRepro.put(test, repro);
         }
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -117,7 +117,7 @@ public class DebugTask {
                 Configuration failingConfig = this.startDebugBinary(config);
 
                 // If debugged down to single choice point, then go ahead and return that
-                if (failingConfig.numChoices() == 0) {
+                if (failingConfig != null && failingConfig.numChoices() == 0) {
                     return failingConfig;
                 }
                 // Otherwise should go on until finding better one

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -78,7 +78,8 @@ public class DebugTask {
         Logger.getGlobal().log(Level.SEVERE, "limits : " + limits.getLeft() + "  " + limits.getRight());
 
         if (failingOne != null) {
-            return failingOne.toArgLine();
+            return failingOne.toArgLine() + "\nDEBUG RESULTS FOR " + failingOne.testName + " AT: "
+                + failingOne.getDebugPath();
         }
 
         // The seeds that failed with the full test-suite no longer fail
@@ -87,7 +88,8 @@ public class DebugTask {
         failingOne = this.debugWithConfigurations(retryWOtherSeeds);
 
         if (failingOne != null) {
-            return failingOne.toArgLine();
+            return failingOne.toArgLine() + "\nDEBUG RESULTS FOR " + failingOne.testName + " AT: "
+                + failingOne.getDebugPath();
         }
 
         return "cannot reproduce. may be flaky due to other causes";


### PR DESCRIPTION
This pull request changes the reporting of DebugTask to also report the name of the test to be debugged along with the path to the corresponding debug file.

Note that this requires a change to failsWithConfig to return the actual failing configuration instead of booleans (where null represents no failure) and changes to all callers of failsWithConfig accordingly. Before, a new failing configuration was made wrapped around some existing failing configuration instead of the debugged one, but now to get the path to the debug file the failing configuration from the last debugging is required.