### PR TITLE
Fixing debugging duplicates. Adding a flag nondex.printstack to commu…

### DIFF
--- a/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java
@@ -56,6 +56,8 @@ public class Configuration {
     public final long start;
     public final long end;
 
+    public final boolean shouldPrintStackTrace;
+
     public final String nondexDir;
     public final String nondexJarDir;
 
@@ -71,6 +73,11 @@ public class Configuration {
 
     public Configuration(Mode mode, int seed, Pattern filter, long start, long end, String nondexDir,
             String nondexJarDir, String testName, String executionId) {
+        this(mode, seed, filter, start, end, nondexDir, nondexJarDir, testName, executionId, false);
+    }
+
+    public Configuration(Mode mode, int seed, Pattern filter, long start, long end, String nondexDir,
+            String nondexJarDir, String testName, String executionId, boolean printStackTrace) {
         this.mode = mode;
         this.seed = seed;
         this.filter = filter;
@@ -80,8 +87,10 @@ public class Configuration {
         this.nondexJarDir = nondexJarDir;
         this.testName = testName;
         this.executionId = executionId;
+        this.shouldPrintStackTrace = printStackTrace;
         this.createExecutionDirIfNeeded();
     }
+
 
     public Configuration(String executionId) {
         this(ConfigurationDefaults.DEFAULT_MODE, ConfigurationDefaults.DEFAULT_SEED,
@@ -101,6 +110,7 @@ public class Configuration {
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_SEED + "=" + this.seed);
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_START + "=" + this.start);
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_END + "=" + this.end);
+        sb.append(" -D" + ConfigurationDefaults.PROPERTY_PRINT_STACK + "=" + this.shouldPrintStackTrace);
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_NONDEX_DIR + "=" + this.nondexDir);
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_NONDEX_JAR_DIR + "=" + this.nondexJarDir);
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_EXECUTION_ID + "=" + this.executionId);
@@ -115,6 +125,7 @@ public class Configuration {
                 + ConfigurationDefaults.PROPERTY_SEED + "=" + this.seed + "\n"
                 + ConfigurationDefaults.PROPERTY_START + "=" + this.start + "\n"
                 + ConfigurationDefaults.PROPERTY_END + "=" + this.end + "\n"
+                + ConfigurationDefaults.PROPERTY_PRINT_STACK + "=" + this.shouldPrintStackTrace + "\n"
                 + ConfigurationDefaults.PROPERTY_NONDEX_DIR + "=" + this.nondexDir + "\n"
                 + ConfigurationDefaults.PROPERTY_NONDEX_JAR_DIR + "=" + this.nondexJarDir + "\n"
                 + ConfigurationDefaults.PROPERTY_EXECUTION_ID + "=" + this.executionId + "\n"
@@ -144,6 +155,11 @@ public class Configuration {
         final long end = Long.parseLong(
                 props.getProperty(ConfigurationDefaults.PROPERTY_END, ConfigurationDefaults.DEFAULT_END_STR));
 
+        final boolean shouldPrintStacktrace = Boolean.parseBoolean(
+                props.getProperty(ConfigurationDefaults.PROPERTY_PRINT_STACK,
+                        ConfigurationDefaults.DEFAULT_PRINT_STACK_STR));
+
+
         final String nondexDir = props.getProperty(ConfigurationDefaults.PROPERTY_NONDEX_DIR,
                 ConfigurationDefaults.DEFAULT_NONDEX_DIR);
 
@@ -156,7 +172,8 @@ public class Configuration {
 
         final String testName = props.getProperty("test", null);
 
-        return new Configuration(nonDetKind, seed, filter, start, end, nondexDir, nondexJarDir, testName, executionId);
+        return new Configuration(nonDetKind, seed, filter, start, end, nondexDir, nondexJarDir, testName,
+                executionId, shouldPrintStacktrace);
     }
 
     public void createExecutionDirIfNeeded() {

--- a/nondex-common/src/main/java/edu/illinois/nondex/common/ConfigurationDefaults.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/ConfigurationDefaults.java
@@ -60,6 +60,9 @@ public class ConfigurationDefaults {
     public static final String DEFAULT_END_STR = "9223372036854775807";
     public static final long DEFAULT_END = new Long(ConfigurationDefaults.DEFAULT_END_STR);
 
+    public static final String PROPERTY_PRINT_STACK = "nondex.printstack";
+    public static final String DEFAULT_PRINT_STACK_STR = "false";
+
     public static final String PROPERTY_EXECUTION_ID = "nondex.execid";
     public static final String NO_EXECUTION_ID = "NoId";
     public static final String PROPERTY_DEFAULT_EXECUTION_ID = ConfigurationDefaults.NO_EXECUTION_ID;
@@ -84,4 +87,5 @@ public class ConfigurationDefaults {
 
     public static final String PROPERTY_LOGGING_LEVEL = "nondex.logging";
     public static final String DEFAULT_LOGGING_LEVEL = "CONFIG";
+
 }

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
@@ -75,8 +75,6 @@ public class DebugMojo extends AbstractNondexMojo {
             DebugTask debugging = new DebugTask(test, this.surefire, this.originalArgLine,
                     this.mavenProject, this.mavenSession, this.pluginManager, this.testsFailing.get(test));
             String repro = debugging.debug();
-            Logger.getGlobal().log(Level.SEVERE, "REPRO: mvn nondex:nondex " + repro);
-
             testToRepro.put(test, repro);
         }
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -113,8 +113,9 @@ public class DebugTask {
     private Configuration debugWithConfigurations(Set<Configuration> failingConfigurations) {
         Configuration debConfig = null;
         for (Configuration config : failingConfigurations) {
-            if (this.failsOnDry(config) != null) {
-                Configuration failingConfig = this.startDebugBinary(config);
+            Configuration dryConfig;
+            if ((dryConfig = this.failsOnDry(config)) != null) {
+                Configuration failingConfig = this.startDebugBinary(dryConfig);
 
                 // If debugged down to single choice point, then go ahead and return that
                 if (failingConfig != null && failingConfig.numChoices() == 0) {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -155,7 +155,7 @@ public class DebugTask {
             }
         }
         if (failingConfiguration != null) {
-            this.reportDebugInfo(failingConfiguration);
+            return this.reportDebugInfo(failingConfiguration);
         }
         return failingConfiguration;
     }

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -154,7 +154,10 @@ public class DebugTask {
                 break;
             }
         }
-        return this.reportDebugInfo(failingConfiguration);
+        if (failingConfiguration != null) {
+            this.reportDebugInfo(failingConfiguration);
+        }
+        return failingConfiguration;
     }
 
     private Configuration reportDebugInfo(Configuration failingConfiguration) {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
@@ -58,13 +58,13 @@ public class NonDexSurefireExecution extends CleanSurefireExecution {
                 this.executionId);
     }
 
-    public NonDexSurefireExecution(Configuration config, int start, int end, String test, Plugin surefire,
+    public NonDexSurefireExecution(Configuration config, long start, long end, boolean print, String test, Plugin surefire,
             String originalArgLine, MavenProject mavenProject, MavenSession mavenSession,
             BuildPluginManager pluginManager) {
 
         this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager);
         this.configuration = new Configuration(config.mode, config.seed, config.filter, start,
-                end, config.nondexDir, config.nondexJarDir, test, this.executionId);
+                end, config.nondexDir, config.nondexJarDir, test, this.executionId, print);
     }
 
     @Override


### PR DESCRIPTION
…nicate to the runner that the stack needs to be printed when debugging is done. this flag is added to configuration.