### PR TITLE
Fixing debug order and small optimization to debugging

### DIFF
--- a/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
@@ -126,6 +126,11 @@ public class ControlNondeterminism {
             return objs;
         }
 
+        // If size of collection to shuffle has at most one element, no need to shuffle
+        if (objs.size() <= 1) {
+            return objs;
+        }
+
         Random currentRandom = ControlNondeterminism.getRandomnessSource(source);
         // If randomness was null, that means do not shuffle
         if (currentRandom == null) {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
@@ -45,8 +45,8 @@ import edu.illinois.nondex.common.ConfigurationDefaults;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.Utils;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -60,7 +60,7 @@ public class DebugMojo extends AbstractNondexMojo {
 
     private List<String> executions = new LinkedList<>();
 
-    private SetMultimap<String, Configuration> testsFailing = HashMultimap.create();
+    private ListMultimap<String, Configuration> testsFailing = LinkedListMultimap.create();
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -28,8 +28,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package edu.illinois.nondex.plugin;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.logging.Level;
 
 import edu.illinois.nondex.common.Configuration;
@@ -52,11 +52,11 @@ public class DebugTask {
     private MavenProject mavenProject;
     private MavenSession mavenSession;
     private BuildPluginManager pluginManager;
-    private Set<Configuration> failingConfigurations;
+    private List<Configuration> failingConfigurations;
 
     public DebugTask(String test, Plugin surefire, String originalArgLine, MavenProject mavenProject,
             MavenSession mavenSession, BuildPluginManager pluginManager,
-            Set<Configuration> failingConfigurations) {
+            List<Configuration> failingConfigurations) {
         this.test = test;
         this.surefire = surefire;
         this.originalArgLine = originalArgLine;
@@ -84,7 +84,7 @@ public class DebugTask {
 
         // The seeds that failed with the full test-suite no longer fail
         // Searching for different seeds
-        Set<Configuration> retryWOtherSeeds = this.createNewSeedsToRetry();
+        List<Configuration> retryWOtherSeeds = this.createNewSeedsToRetry();
         failingOne = this.debugWithConfigurations(retryWOtherSeeds);
 
         if (failingOne != null) {
@@ -95,10 +95,10 @@ public class DebugTask {
         return "cannot reproduce. may be flaky due to other causes";
     }
 
-    private Set<Configuration> createNewSeedsToRetry() {
+    private List<Configuration> createNewSeedsToRetry() {
         Configuration someFailingConfig = this.failingConfigurations.iterator().next();
         int newSeed = someFailingConfig.seed * ConfigurationDefaults.SEED_FACTOR;
-        Set<Configuration> retryWOtherSeeds = new LinkedHashSet<>();
+        List<Configuration> retryWOtherSeeds = new LinkedList<>();
         for (int i = 0; i < 10; i++) {
             Configuration newConfig = new Configuration(someFailingConfig.mode,
                     Utils.computeIthSeed(i, false, newSeed),
@@ -110,7 +110,7 @@ public class DebugTask {
         return retryWOtherSeeds;
     }
 
-    private Configuration debugWithConfigurations(Set<Configuration> failingConfigurations) {
+    private Configuration debugWithConfigurations(List<Configuration> failingConfigurations) {
         Configuration debConfig = null;
         for (Configuration config : failingConfigurations) {
             Configuration dryConfig;


### PR DESCRIPTION
This pull request makes sure debugging goes over the seeds in a List order for consistency.

It also adds logic in shuffling to not shuffle when there is at most one element in the collection, as to help with debugging and not searching as large a range.