### PR TITLE
Global debugging

### DIFF
--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -73,10 +73,10 @@ public class DebugTask {
         // I think this entire string result returning is very ugly, and checking success through null-checks
         // TODO(gyori): refactor this crap.
 
-        // Try debugging test at different levels, from individual test all the way to entire test suite (being null)
+        // Try debugging test at different levels, from individual test all the way to entire test suite (being empty)
         String defaultTest = this.test;                                     // Save the original test wanting to debug
         String testClass = this.test.substring(0, this.test.indexOf('#'));  // Test class parsing
-        for (String test : new String[]{defaultTest, testClass, null}) {
+        for (String test : new String[]{defaultTest, testClass, ""}) {
             this.test = test;
             String result = this.tryDebugSeeds();
             if (result != null) {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -70,19 +70,15 @@ public class DebugTask {
         //The test must have failed if it's being debugged, ergo there should exist a failing configuration
         assert (!this.failingConfigurations.isEmpty());
 
-        // I think this entire string result returning is very ugly, and checking succes through null-checks
+        // I think this entire string result returning is very ugly, and checking success through null-checks
         // TODO(gyori): refactor this crap.
-        String result = this.tryDebugSeeds();
-        if (result != null) {
-            return result;
-        }
 
-        // if the test is null, it will run the entire test suite (one may consider doing this more fine grainedly
-        // going to class, before jumping all the way to project
-        this.test = null;
-        result = this.tryDebugSeeds();
-        if (result != null) {
-            return result;
+        // Try debugging test at different levels, from individual test all the way to entire test suite (being null)
+        for (String test : new String[]{this.test, null}) {
+            String result = this.tryDebugSeeds();
+            if (result != null) {
+                return result;
+            }
         }
 
         return "cannot reproduce. may be flaky due to other causes";

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -74,7 +74,9 @@ public class DebugTask {
         // TODO(gyori): refactor this crap.
 
         // Try debugging test at different levels, from individual test all the way to entire test suite (being null)
-        for (String test : new String[]{this.test, null}) {
+        String defaultTest = this.test; // Save the original test wanting to debug
+        for (String test : new String[]{defaultTest, null}) {
+            this.test = test;
             String result = this.tryDebugSeeds();
             if (result != null) {
                 return result;

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -74,8 +74,9 @@ public class DebugTask {
         // TODO(gyori): refactor this crap.
 
         // Try debugging test at different levels, from individual test all the way to entire test suite (being null)
-        String defaultTest = this.test; // Save the original test wanting to debug
-        for (String test : new String[]{defaultTest, null}) {
+        String defaultTest = this.test;                                     // Save the original test wanting to debug
+        String testClass = this.test.substring(0, this.test.indexOf('#'));  // Test class parsing
+        for (String test : new String[]{defaultTest, testClass, null}) {
             this.test = test;
             String result = this.tryDebugSeeds();
             if (result != null) {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
@@ -43,6 +43,8 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.project.MavenProject;
 
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
 public class NonDexSurefireExecution extends CleanSurefireExecution {
 
     private NonDexSurefireExecution(Plugin surefire, String originalArgLine,
@@ -71,6 +73,11 @@ public class NonDexSurefireExecution extends CleanSurefireExecution {
     protected void setupArgline() {
         String localRepo = this.mavenSession.getSettings().getLocalRepository();
         String pathToNondex = this.getPathToNondexJar(localRepo);
+        // Only modify test in configuration if not null, because that means is debugging
+        Xpp3Dom configElement = (Xpp3Dom)this.surefire.getConfiguration();
+        if (configElement != null) {
+            configElement.getChild("test").setValue(this.configuration.testName);
+        }
         Logger.getGlobal().log(Level.FINE, "Running surefire with: " + this.configuration.toArgLine());
         this.mavenProject.getProperties().setProperty("argLine",
                 "" + "-Xbootclasspath/p:" + pathToNondex + " " + this.originalArgLine + " "


### PR DESCRIPTION
This pull request allows debugging to run higher levels of granularity instead of always the set test, as it requires the configuration in the surefire to be updated to use the different test class or empty (for project).

Also adds test class as possible level.