### PR TITLE
Fixed to add check if failure is skipped

### DIFF
--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
@@ -100,7 +100,8 @@ public class CleanSurefireExecution {
                 Set<String> failingTests = new LinkedHashSet<>();
                 for (ReportTestSuite report : parser.parseXMLReportFiles()) {
                     for (ReportTestCase testCase : report.getTestCases()) {
-                        if (testCase.hasFailure()) {
+                        // Record if failed, but not skipped
+                        if (testCase.hasFailure() && !"skipped".equals(testCase.getFailureType())) {
                             failingTests.add(testCase.getFullClassName() + '#' + testCase.getName());
                         }
                     }


### PR DESCRIPTION
Surefire for some reason counts skipped as failure, which we don't want, so this simply checks that.