### PR TITLE
escaping paths to account for space

### DIFF
--- a/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java
@@ -111,8 +111,8 @@ public class Configuration {
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_START + "=" + this.start);
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_END + "=" + this.end);
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_PRINT_STACK + "=" + this.shouldPrintStackTrace);
-        sb.append(" -D" + ConfigurationDefaults.PROPERTY_NONDEX_DIR + "=" + this.nondexDir);
-        sb.append(" -D" + ConfigurationDefaults.PROPERTY_NONDEX_JAR_DIR + "=" + this.nondexJarDir);
+        sb.append(" -D" + ConfigurationDefaults.PROPERTY_NONDEX_DIR + "=\"" + this.nondexDir + "\"");
+        sb.append(" -D" + ConfigurationDefaults.PROPERTY_NONDEX_JAR_DIR + "=\"" + this.nondexJarDir + "\"");
         sb.append(" -D" + ConfigurationDefaults.PROPERTY_EXECUTION_ID + "=" + this.executionId);
         sb.append(this.testName == null ? "" : " -Dtest=" + this.testName);
         return sb.toString();

--- a/nondex-instrumentation/pom.xml
+++ b/nondex-instrumentation/pom.xml
@@ -104,7 +104,7 @@
         </executions>
         <configuration>
           <mainClass>edu.illinois.nondex.instr.Main</mainClass>
-          <commandlineArgs>${project.basedir}/resources/out.jar</commandlineArgs>
+          <commandlineArgs>"${project.basedir}/resources/out.jar"</commandlineArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
@@ -91,6 +91,6 @@ public class NonDexSurefireExecution extends CleanSurefireExecution {
             + File.pathSeparator + Paths.get(localRepo, "edu", "illinois", "nondex-common", ConfigurationDefaults.VERSION,
                               "nondex-common-" + ConfigurationDefaults.VERSION + ".jar");
         Logger.getGlobal().log(Level.FINE, "The nondex path is: " + result);
-        return result;
+        return "\"" + result + "\"";
     }
 }

--- a/nondex-test/pom.xml
+++ b/nondex-test/pom.xml
@@ -93,7 +93,7 @@
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <argLine>-Xbootclasspath/p:${project.basedir}/../nondex-instrumentation/resources/out.jar:${project.build.directory}/../../nondex-common/target/classes/</argLine>
+          <argLine>-Xbootclasspath/p:"${project.basedir}/../nondex-instrumentation/resources/out.jar:${project.build.directory}/../../nondex-common/target/classes/"</argLine>
           <systemPropertyVariables>
             <buildDirectory>${project.build.directory}</buildDirectory>
           </systemPropertyVariables>


### PR DESCRIPTION
NonDex did not work if the path to your current project had any space in it. This should fix that.