### PR TITLE
Modified checkstyle to check for system print

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -41,7 +41,7 @@ Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
     <module name="MissingOverride"/>
 
     <module name="Regexp">
-      <property name="format" value="System\.out\.println"/>
+      <property name="format" value="System\.(out|err)\.print"/>
       <property name="illegalPattern" value="true"/>
       <property name="ignoreComments" value="true"/>
     </module>


### PR DESCRIPTION
Checkstyle should check for all kinds of print, not just println