### PR TITLE
Modify JVMShutdownHook to throw RuntimeException when IOException occurs

### DIFF
--- a/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
@@ -108,10 +108,7 @@ public class ControlNondeterminism {
             } catch (IOException ioe) {
                 Logger.getGlobal().log(Level.SEVERE,
                         "IOException when printing shuffling counts in shutdown hook.", ioe);
-            } catch (Throwable ex) {
-                Logger.getGlobal().log(Level.SEVERE,
-                        "Some Exception when printing shuffling counts in shutdown hook.", ex);
-                throw ex;
+                throw new RuntimeException(ioe);
             }
         }
     }

--- a/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
@@ -109,6 +109,10 @@ public class ControlNondeterminism {
                 Logger.getGlobal().log(Level.SEVERE,
                         "IOException when printing shuffling counts in shutdown hook.", ioe);
                 throw new RuntimeException(ioe);
+            } catch (Throwable ex) {
+                Logger.getGlobal().log(Level.SEVERE,
+                        "Some Exception when printing shuffling counts in shutdown hook.", ex);
+                throw ex;
             }
         }
     }


### PR DESCRIPTION
@alexgyori 
Since we are overriding a method with no "throws" signature and IOException is not a runtime exception, so I choose to throw a RunTimeException.
And I am kind of confused why there are two catch blocks in the original code. Code in the try block will only throw IOException, I don't see any chance that it will catch any other exceptions.