### PR TITLE
Fix the out-of-date help text for mode of debug in the maven plugin

### DIFF
--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
@@ -70,8 +70,6 @@ public abstract class AbstractNonDexMojo extends AbstractMojo {
      * Section III.B in http://mir.cs.illinois.edu/~awshi2/publications/ICST2016.pdf)
      * The options are:
      * FULL: shuffle on each invocation of methods with nondeterministic specs
-     * ID: does not shuffle during invocations on objects with same identity
-     * EQ: does not shuffle during invocations on objects that are equal
      * ONE: only shuffle on the first invocation of an object
      */
     @Parameter(property = ConfigurationDefaults.PROPERTY_MODE, defaultValue = ConfigurationDefaults.DEFAULT_MODE_STR)


### PR DESCRIPTION
This fixes issue #81 as https://github.com/TestingResearchIllinois/NonDex/blob/a1d2fa21e19acd5453abf4c549b61101ac115e3b/nondex-common/src/main/java/edu/illinois/nondex/common/Mode.java#L32 indicates, there are only two modes: ONE and FULL. This PR removes the incorrect part.


Please note in order for the change to show up, you need to use the snapshot version when using the plugin.