### PR TITLE
Updating checkstyle due to security vulnerabilities

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -71,13 +71,11 @@ Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
     <module name="OneTopLevelClass"/>
     <module name="NoLineWrap"/>
     <module name="EmptyBlock">
-      <property name="option" value="stmt"/>
+      <property name="option" value="statement"/>
       <property name="tokens" value="LITERAL_WHILE, LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_DO, LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, INSTANCE_INIT, STATIC_INIT, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_CASE, LITERAL_DEFAULT, ARRAY_INIT"/>
     </module>
     <module name="NeedBraces"/>
-    <module name="LeftCurly">
-      <property name="maxLineLength" value="100"/>
-    </module>
+    <module name="LeftCurly"/>
     <module name="RightCurly"/>
     <module name="RightCurly">
       <property name="option" value="alone"/>

--- a/nondex-annotations/pom.xml
+++ b/nondex-annotations/pom.xml
@@ -30,7 +30,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.17</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
         <executions>

--- a/nondex-common/pom.xml
+++ b/nondex-common/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
           <groupId>com.puppycrawl.tools</groupId>
           <artifactId>checkstyle</artifactId>
-          <version>6.17</version>
+          <version>8.18</version>
         </dependency>
         </dependencies>
         <executions>

--- a/nondex-instrumentation/pom.xml
+++ b/nondex-instrumentation/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>com.puppycrawl.tools</groupId>
           <artifactId>checkstyle</artifactId>
-          <version>6.17</version>
+          <version>8.18</version>
         </dependency>
         </dependencies>
         <executions>

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/ConcurrentHashMapShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/ConcurrentHashMapShufflingAdder.java
@@ -28,7 +28,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package edu.illinois.nondex.instr;
 
-
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;

--- a/nondex-instrumentation/src/test/java/edu/illinois/nondex/instr/InstrumenterTest.java
+++ b/nondex-instrumentation/src/test/java/edu/illinois/nondex/instr/InstrumenterTest.java
@@ -28,7 +28,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package edu.illinois.nondex.instr;
 
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;

--- a/nondex-maven-plugin/pom.xml
+++ b/nondex-maven-plugin/pom.xml
@@ -89,7 +89,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.17</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
         <executions>

--- a/nondex-test/pom.xml
+++ b/nondex-test/pom.xml
@@ -39,7 +39,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.17</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Updating the checkstyle version to 8.18 due to security vulnerabilities. Additionally, updating the configuration files to match the new updated version and reformatting some source files that now fail some checkstyle checks.