### PR TITLE
Resetting the Surefire configuration between runs

### DIFF
--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
@@ -87,6 +87,10 @@ public class CleanSurefireExecution {
     }
 
     public void run() throws MojoExecutionException {
+        Xpp3Dom origNode = null;
+        if (this.surefire.getConfiguration() != null) {
+            origNode = new Xpp3Dom((Xpp3Dom) this.surefire.getConfiguration());
+        }
         try {
             Xpp3Dom domNode = this.applyNonDexConfig((Xpp3Dom) this.surefire.getConfiguration());
             this.setupArgline(domNode);
@@ -123,6 +127,8 @@ public class CleanSurefireExecution {
         } catch (Throwable tr) {
             Logger.getGlobal().log(Level.SEVERE, "Some exception that is highly unexpected: ", tr);
             throw tr;
+        } finally {
+            this.surefire.setConfiguration(origNode);
         }
     }
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
@@ -64,9 +64,11 @@ public class CleanSurefireExecution {
 
     protected String originalArgLine;
 
+    protected boolean resetSurefire;
+
     protected CleanSurefireExecution(Plugin surefire, String originalArgLine, String executionId,
             MavenProject mavenProject, MavenSession mavenSession, BuildPluginManager pluginManager,
-            String nondexDir) {
+            String nondexDir, boolean resetSurefire) {
         this.executionId = executionId;
         this.surefire = surefire;
         this.originalArgLine = sanitizeAndRemoveEnvironmentVars(originalArgLine);
@@ -74,6 +76,13 @@ public class CleanSurefireExecution {
         this.mavenSession = mavenSession;
         this.pluginManager = pluginManager;
         this.configuration = new Configuration(executionId, nondexDir);
+        this.resetSurefire = resetSurefire;
+    }
+
+    protected CleanSurefireExecution(Plugin surefire, String originalArgLine, String executionId,
+            MavenProject mavenProject, MavenSession mavenSession, BuildPluginManager pluginManager,
+            String nondexDir) {
+        this(surefire, originalArgLine, executionId, mavenProject, mavenSession, pluginManager, nondexDir, false);
     }
 
     public CleanSurefireExecution(Plugin surefire, String originalArgLine, MavenProject mavenProject,
@@ -128,7 +137,9 @@ public class CleanSurefireExecution {
             Logger.getGlobal().log(Level.SEVERE, "Some exception that is highly unexpected: ", tr);
             throw tr;
         } finally {
-            this.surefire.setConfiguration(origNode);
+            if (resetSurefire) {
+                this.surefire.setConfiguration(origNode);
+            }
         }
     }
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -216,7 +216,7 @@ public class DebugTask {
     private Configuration failsWithConfig(Configuration config, long start, long end, boolean print) {
         NonDexSurefireExecution execution = new NonDexSurefireExecution(config,
                 start, end, print, this.test, this.surefire, this.originalArgLine,
-                this.mavenProject, this.mavenSession, this.pluginManager);
+                this.mavenProject, this.mavenSession, this.pluginManager, true);
         try {
             execution.run();
         } catch (Throwable thr) {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
@@ -49,24 +49,25 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 public class NonDexSurefireExecution extends CleanSurefireExecution {
 
     private NonDexSurefireExecution(Plugin surefire, String originalArgLine, MavenProject mavenProject,
-                                    MavenSession mavenSession, BuildPluginManager pluginManager, String nondexDir) {
+                                    MavenSession mavenSession, BuildPluginManager pluginManager, String nondexDir,
+                                    boolean resetSurefire) {
         super(surefire, originalArgLine, Utils.getFreshExecutionId(),
-                mavenProject, mavenSession, pluginManager, nondexDir);
+                mavenProject, mavenSession, pluginManager, nondexDir, resetSurefire);
     }
 
     public NonDexSurefireExecution(Mode mode, int seed, Pattern filter, long start, long end, String nondexDir,
             String nondexJarDir, Plugin surefire, String originalArgLine, MavenProject mavenProject,
             MavenSession mavenSession, BuildPluginManager pluginManager) {
-        this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager, nondexDir);
+        this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager, nondexDir, false);
         this.configuration = new Configuration(mode, seed, filter, start, end, nondexDir, nondexJarDir, null,
                 this.executionId, Logger.getGlobal().getLoggingLevel());
     }
 
     public NonDexSurefireExecution(Configuration config, long start, long end, boolean print, String test, Plugin surefire,
             String originalArgLine, MavenProject mavenProject, MavenSession mavenSession,
-            BuildPluginManager pluginManager) {
+            BuildPluginManager pluginManager, boolean resetSurefire) {
 
-        this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager, config.nondexDir);
+        this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager, config.nondexDir, resetSurefire);
         this.configuration = new Configuration(config.mode, config.seed, config.filter, start,
                 end, config.nondexDir, config.nondexJarDir, test, this.executionId,
                 Logger.getGlobal().getLoggingLevel(), print);

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
@@ -80,6 +80,9 @@ public class NonDexSurefireExecution extends CleanSurefireExecution {
         // Only modify test in configuration if not null, because that means is debugging
         Xpp3Dom configElement = (Xpp3Dom)this.surefire.getConfiguration();
         if (configElement != null) {
+            if (configElement.getChild("test") == null) {
+                configElement.addChild(new Xpp3Dom("test"));
+            }
             configElement.getChild("test").setValue(this.configuration.testName);
         }
         String argLineToSet = "" + "-Xbootclasspath/p:" + pathToNondex + File.pathSeparator


### PR DESCRIPTION
In Issue #123, debug mode throws an NPE when debugging multiple tests because, upon reaching to debug the second test, the configuration is still stuck with using the execution ID from debugging the prior test.

The reason is that in between runs of NonDex the updated Surefire configuration (which passes in the relevant configuration options as arguments for running) is not reset, and it maintains some configuration options from before. The later runs, when parsing the arguments, always parses the old ones. This pull request resets the Surefire configuration between runs.

The other change, to NonDexSurefireExecution.java, is a by-product of doing the resetting, because integration tests now fail due to having configuration nodes without a <test> child. The change there simply adds one if it does not exist beforehand.