### PR TITLE
Removing shuffling for annotations

### DIFF
--- a/nondex-core/src/main/java/java/lang/Class.java
+++ b/nondex-core/src/main/java/java/lang/Class.java
@@ -3338,7 +3338,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since 1.5
      */
     public Annotation[] getAnnotations() {
-        return edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(AnnotationParser.toArray(annotationData().annotations));
+        return AnnotationParser.toArray(annotationData().annotations);
     }
 
     /**
@@ -3369,7 +3369,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since 1.5
      */
     public Annotation[] getDeclaredAnnotations()  {
-        return edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(AnnotationParser.toArray(annotationData().declaredAnnotations));
+        return AnnotationParser.toArray(annotationData().declaredAnnotations);
     }
 
     // annotation data that might get invalidated when JVM TI RedefineClasses() is called

--- a/nondex-core/src/main/java/java/lang/reflect/Field.java
+++ b/nondex-core/src/main/java/java/lang/reflect/Field.java
@@ -1123,14 +1123,14 @@ class Field extends AccessibleObject implements Member {
     public <T extends Annotation> T[] getAnnotationsByType(Class<T> annotationClass) {
         Objects.requireNonNull(annotationClass);
 
-        return edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(AnnotationSupport.getDirectlyAndIndirectlyPresent(declaredAnnotations(), annotationClass));
+        return AnnotationSupport.getDirectlyAndIndirectlyPresent(declaredAnnotations(), annotationClass);
     }
 
     /**
      * {@inheritDoc}
      */
     public Annotation[] getDeclaredAnnotations()  {
-        return edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(AnnotationParser.toArray(declaredAnnotations()));
+        return AnnotationParser.toArray(declaredAnnotations());
     }
 
     private transient Map<Class<? extends Annotation>, Annotation> declaredAnnotations;

--- a/nondex-core/src/main/java/java/lang/reflect/Method.java
+++ b/nondex-core/src/main/java/java/lang/reflect/Method.java
@@ -612,7 +612,7 @@ public final class Method extends Executable {
      * @since 1.5
      */
     public Annotation[] getDeclaredAnnotations()  {
-        return edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(super.getDeclaredAnnotations());
+        return super.getDeclaredAnnotations();
     }
 
     /**
@@ -621,11 +621,7 @@ public final class Method extends Executable {
      */
     @Override
     public Annotation[][] getParameterAnnotations() {
-	Annotation[][] anns = sharedGetParameterAnnotations(parameterTypes, parameterAnnotations);
-	for (int i = 0;i<anns.length;i++) {
-	    anns[i] = edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(anns[i]);
-	}
-        return anns;
+        return sharedGetParameterAnnotations(parameterTypes, parameterAnnotations);
     }
 
     /**


### PR DESCRIPTION
After re-examining the documentation related to getting annotations, it seems there is no language there that specifically states that the order is not guaranteed. As such, it may not be appropriate to shuffle the annotation order. This pull request simply removes the shuffling for uses of getting annotations.

If you know of where we initially found that annotation order is not guaranteed, please point it out and then we can keep the shuffling for the annotation order.