### PR TITLE
Update README to use the snapshot version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use NonDex, add the plugin to the plugins section under the build section in 
       <plugin>
         <groupId>edu.illinois</groupId>
         <artifactId>nondex-maven-plugin</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This is related to #121.

It looks like the "stable" version in maven central failed to detect bugs in some projects but the snapshot version could. This proposes to use the snapshot version in README.