### PR TITLE
Revert "Introducing option to reset Surefire configuration as to only…

### DIFF
--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
@@ -64,11 +64,9 @@ public class CleanSurefireExecution {
 
     protected String originalArgLine;
 
-    protected boolean resetSurefire;
-
     protected CleanSurefireExecution(Plugin surefire, String originalArgLine, String executionId,
             MavenProject mavenProject, MavenSession mavenSession, BuildPluginManager pluginManager,
-            String nondexDir, boolean resetSurefire) {
+            String nondexDir) {
         this.executionId = executionId;
         this.surefire = surefire;
         this.originalArgLine = sanitizeAndRemoveEnvironmentVars(originalArgLine);
@@ -76,13 +74,6 @@ public class CleanSurefireExecution {
         this.mavenSession = mavenSession;
         this.pluginManager = pluginManager;
         this.configuration = new Configuration(executionId, nondexDir);
-        this.resetSurefire = resetSurefire;
-    }
-
-    protected CleanSurefireExecution(Plugin surefire, String originalArgLine, String executionId,
-            MavenProject mavenProject, MavenSession mavenSession, BuildPluginManager pluginManager,
-            String nondexDir) {
-        this(surefire, originalArgLine, executionId, mavenProject, mavenSession, pluginManager, nondexDir, false);
     }
 
     public CleanSurefireExecution(Plugin surefire, String originalArgLine, MavenProject mavenProject,
@@ -137,9 +128,7 @@ public class CleanSurefireExecution {
             Logger.getGlobal().log(Level.SEVERE, "Some exception that is highly unexpected: ", tr);
             throw tr;
         } finally {
-            if (resetSurefire) {
-                this.surefire.setConfiguration(origNode);
-            }
+            this.surefire.setConfiguration(origNode);
         }
     }
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -216,7 +216,7 @@ public class DebugTask {
     private Configuration failsWithConfig(Configuration config, long start, long end, boolean print) {
         NonDexSurefireExecution execution = new NonDexSurefireExecution(config,
                 start, end, print, this.test, this.surefire, this.originalArgLine,
-                this.mavenProject, this.mavenSession, this.pluginManager, true);
+                this.mavenProject, this.mavenSession, this.pluginManager);
         try {
             execution.run();
         } catch (Throwable thr) {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
@@ -49,25 +49,24 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 public class NonDexSurefireExecution extends CleanSurefireExecution {
 
     private NonDexSurefireExecution(Plugin surefire, String originalArgLine, MavenProject mavenProject,
-                                    MavenSession mavenSession, BuildPluginManager pluginManager, String nondexDir,
-                                    boolean resetSurefire) {
+                                    MavenSession mavenSession, BuildPluginManager pluginManager, String nondexDir) {
         super(surefire, originalArgLine, Utils.getFreshExecutionId(),
-                mavenProject, mavenSession, pluginManager, nondexDir, resetSurefire);
+                mavenProject, mavenSession, pluginManager, nondexDir);
     }
 
     public NonDexSurefireExecution(Mode mode, int seed, Pattern filter, long start, long end, String nondexDir,
             String nondexJarDir, Plugin surefire, String originalArgLine, MavenProject mavenProject,
             MavenSession mavenSession, BuildPluginManager pluginManager) {
-        this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager, nondexDir, false);
+        this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager, nondexDir);
         this.configuration = new Configuration(mode, seed, filter, start, end, nondexDir, nondexJarDir, null,
                 this.executionId, Logger.getGlobal().getLoggingLevel());
     }
 
     public NonDexSurefireExecution(Configuration config, long start, long end, boolean print, String test, Plugin surefire,
             String originalArgLine, MavenProject mavenProject, MavenSession mavenSession,
-            BuildPluginManager pluginManager, boolean resetSurefire) {
+            BuildPluginManager pluginManager) {
 
-        this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager, config.nondexDir, resetSurefire);
+        this(surefire, originalArgLine, mavenProject, mavenSession, pluginManager, config.nondexDir);
         this.configuration = new Configuration(config.mode, config.seed, config.filter, start,
                 end, config.nondexDir, config.nondexJarDir, test, this.executionId,
                 Logger.getGlobal().getLoggingLevel(), print);


### PR DESCRIPTION
… reset during debugging"

This reverts commit a447744e75c7695b3966368519a97e2046708a05.

We realize this commit will fail to detect some tests, following is an example.
```
import org.junit.Test;
import java.util.*;
public class MyTest{
   @Test
   public void owntest()
   {
      HashSettest = new HashSet();
      test.add(null);
      test.add("123 ");
      Iterator iter = test.iterator();
      iter.next();
      System.out.println(((String)(iter.next())).trim()); // if iter.next() is null, will throw NPE
   }
}
```

Reverting this commit will make it work. Maybe we need to investigate more but I am reverting it as a workaround at this point.

