### PR TITLE
Automate set up on pom.xmls for Nondex

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,18 @@ Build (Maven):
 Use (Maven):
 ============
 
-To use NonDex, add the plugin to the plugins section under the build section in your pom:
+### Automatically setting up the pom.xmls for Nondex
+
+Run the following command to automatically setup the pom.xml for Nondex.
+
+
+```shell
+./pom-modify/modify-project.sh path_to_maven_project 
+```
+Note: This script also installs idFlakies.
+
+### Manually setting up the pom.xmls for Nondex
+Add the plugin to the plugins section under the build section in all pom files:
 
 ```xml
 <project>
@@ -51,6 +62,12 @@ To use NonDex, add the plugin to the plugins section under the build section in 
   </build>
 </project>
 ```
+
+Before running Nondex, run:
+    
+    mvn install
+    mvn test
+
 
 To find if you have flaky tests, run:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Use (Maven):
 
 ### Automatically setting up the pom.xmls for Nondex
 
-Run the following command to automatically setup the pom.xml for Nondex.
+Run the following command to automatically setup the pom.xmls for Nondex.
 
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add the plugin to the plugins section under the build section in all pom files:
 
 Before running Nondex, run:
     
-    mvn install
+    mvn install -DskipTests
     mvn test
 
 

--- a/pom-modify/modify-project.sh
+++ b/pom-modify/modify-project.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [[ $1 == "" ]]; then
+    echo "arg1 - the path to the project, where high-level pom.xml is"
+    exit
+fi
+
+# Check if python is installed
+type -P python3 >/dev/null 2>&1 && echo "You need python3 to run this script but you have it installed."
+
+# Set variables
+project_path=$1
+current=`pwd`
+working_dir=`dirname $0`
+
+# Run script.py
+cd ${project_path}
+project_path=`pwd`
+cd - > /dev/null
+
+cd ${working_dir}
+
+python3 pom-modify.py ${project_path}
+echo "Plugins have been installed in the targeted project."

--- a/pom-modify/pom-modify.py
+++ b/pom-modify/pom-modify.py
@@ -1,0 +1,113 @@
+import xml.etree.ElementTree as ET
+import re
+import xml.dom.minidom as minidom
+import os
+import sys
+
+def nondex_xml_element():
+    plugin = ET.Element('plugin')
+    
+    groupId = ET.SubElement(plugin, 'groupId')
+    groupId.text = 'edu.illinois'
+    
+    artifactId = ET.SubElement(plugin, 'artifactId')
+    artifactId.text = 'nondex-maven-plugin'
+    
+    version = ET.SubElement(plugin, 'version')
+    version.text = '1.1.2'
+
+    return plugin
+
+def idflakies_element():
+    plugin = ET.Element('plugin')
+    
+    plugin_groupId = ET.SubElement(plugin, 'groupId')
+    plugin_groupId.text = 'edu.illinois.cs'
+    
+    plugin_artifactId = ET.SubElement(plugin, 'artifactId')
+    plugin_artifactId.text = 'testrunner-maven-plugin'
+    
+    plugin_version = ET.SubElement(plugin, 'version')
+    plugin_version.text = '1.0'
+    
+    dependencies = ET.SubElement(plugin, 'dependencies')
+    dependency = ET.SubElement(dependencies, 'dependency')
+    dep_groupId = ET.SubElement(dependency, 'groupId')
+    dep_groupId.text = 'edu.illinois.cs'
+    
+    dep_artifactId = ET.SubElement(dependency, 'artifactId')
+    dep_artifactId.text = 'idflakies'
+    
+    dep_version = ET.SubElement(dependency, 'version')
+    dep_version.text = '1.0.2'
+    
+    config = ET.SubElement(plugin, 'configuration')
+    class_name = ET.SubElement(config, 'className')
+    class_name.text = 'edu.illinois.cs.dt.tools.detection.DetectorPlugin'
+    return plugin
+
+def get_namespace(element):
+    m = re.match('\{.*\}', element.tag)
+    return m.group(0) if m else ''
+
+def find_elem(target, branch, ns):
+    for child in branch:
+        if child.tag == '{}{}'.format(ns, target):
+            return child
+    return None
+
+def add_plugin_dependency(to_be_added, root, ns):
+    build = find_elem('build', root, ns)
+    if not build:
+        build = ET.Element('{}build'.format(ns))
+        root.append(build)
+
+    plugins = find_elem('plugins', build, ns)
+    if not plugins:
+        plugins = ET.Element('{}plugins'.format(ns))
+        build.append(plugins)
+    
+    plugins.append(to_be_added)
+    
+def xml_prettify(root, indent='  '):
+    stringified = ET.tostring(root).decode()
+    e = minidom.parseString(stringified)
+    dom_string = e.toprettyxml(indent=indent)
+    dom_string = os.linesep.join([s for s in dom_string.splitlines() if s.strip()])
+    return dom_string
+
+def modify_pom(path_to_pom):
+    xml_tree = ET.parse(path_to_pom)
+    root = xml_tree.getroot()
+    namespace = get_namespace(root)
+    if namespace != '':
+        ET.register_namespace('', get_namespace(root)[1:-1])
+
+    add_plugin_dependency(nondex_xml_element(), root, namespace)
+    add_plugin_dependency(idflakies_element(), root, namespace)
+
+    dom_str = xml_prettify(root, indent='  ')
+
+    with open(path_to_pom, 'w') as f:
+        f.write(dom_str)
+
+def modify_all_poms(path):
+    potential_path = '{}/pom.xml'.format(path)
+    try:
+        modify_pom(potential_path)
+    except FileNotFoundError:
+        pass
+    
+    for dir in os.listdir(path):
+        next_dir = os.path.join(path, dir)
+        if os.path.isdir(next_dir):
+            modify_all_poms(next_dir)
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print('Missing argument: python3 pom-modify.py <path-to-maven-project>')
+    else:
+        if os.path.exists(sys.argv[1]):
+            modify_all_poms(sys.argv[1])
+        else:
+            print("No path found")


### PR DESCRIPTION
Manually setting up the pom.xml files for Nondex takes too long, especially when working with a big repo with many modules. The python script adds the Nondex plugin to all the pom files in one repo. In addition, it also adds the idFlakies plugin. The user will be able to run the bash script and pass the path to the project e.g. `./pom-modify/modify-project.sh path_to_maven_project `. No more manual setting up for Nondex. 