### PR TITLE
Rewrite custom Level class in place of java.util.logging.Level

### DIFF
--- a/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java
@@ -42,7 +42,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 public class Configuration {

--- a/nondex-common/src/main/java/edu/illinois/nondex/common/Level.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/Level.java
@@ -28,38 +28,32 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package edu.illinois.nondex.common;
 
-import java.io.PrintStream;
+public enum Level {
+    ALL(Integer.MIN_VALUE, "ALL"),
+    FINEST(300, "FINEST"),
+    FINER(400, "FINER"),
+    FINE(500, "FINE"),
+    CONFIG(700, "CONFIG"),
+    INFO(800, "INFO"),
+    WARNING(900, "WARNING"),
+    SEVERE(1000, "SEVERE"),
+    OFF(Integer.MAX_VALUE, "OFF");
 
-public class Logger {
+    private final int severity;
 
-    private static final Logger INSTANCE = new Logger();
-    private PrintStream out = System.out;
-    private Level level = Level.CONFIG;
-
-    public void setLoggingLevel(Level level) {
-        this.level = level;
+    private Level(int severity, String name) {
+        this.severity = severity;
     }
 
-    public Level getLoggingLevel() {
-        return this.level;
+    public static Level parse(String name) {
+        return Level.valueOf(name);
     }
 
-    public static Logger getGlobal() {
-        return Logger.INSTANCE;
+    public final String getName() {
+        return name();
     }
 
-    public void log(Level lev, String msg, Throwable thr) {
-        if (lev.intValue() < this.level.intValue()) {
-            return;
-        }
-        this.out.println(lev.toString() + ": " + msg);
-        this.out.println(thr);
-    }
-
-    public void log(Level lev, String msg) {
-        if (lev.intValue() < this.level.intValue()) {
-            return;
-        }
-        this.out.println(lev.toString() + ": " + msg);
+    public final int intValue() {
+        return severity;
     }
 }

--- a/nondex-common/src/main/java/edu/illinois/nondex/common/NonDex.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/NonDex.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.logging.Level;
 
 public class NonDex {
 

--- a/nondex-common/src/main/java/edu/illinois/nondex/common/Utils.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/Utils.java
@@ -36,7 +36,6 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Properties;
-import java.util.logging.Level;
 import javax.xml.bind.DatatypeConverter;
 
 public class Utils {

--- a/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
@@ -34,9 +34,9 @@ import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Level;
 
 import edu.illinois.nondex.common.Configuration;
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.NonDex;
 

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/CVFactory.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/CVFactory.java
@@ -29,9 +29,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package edu.illinois.nondex.instr;
 
 import java.security.NoSuchAlgorithmException;
-import java.util.logging.Level;
 import java.util.zip.ZipFile;
 
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 
 import org.objectweb.asm.ClassVisitor;

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
@@ -40,11 +40,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 
 import org.objectweb.asm.ClassReader;

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
@@ -36,9 +36,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
-import java.util.logging.Level;
 
 import edu.illinois.nondex.common.ConfigurationDefaults;
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.Mode;
 import edu.illinois.nondex.common.Utils;

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/CleanSurefireExecution.java
@@ -32,11 +32,11 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import edu.illinois.nondex.common.Configuration;
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.Utils;
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
@@ -38,10 +38,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.logging.Level;
 
 import edu.illinois.nondex.common.Configuration;
 import edu.illinois.nondex.common.ConfigurationDefaults;
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.Utils;
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugTask.java
@@ -30,10 +30,10 @@ package edu.illinois.nondex.plugin;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Level;
 
 import edu.illinois.nondex.common.Configuration;
 import edu.illinois.nondex.common.ConfigurationDefaults;
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.Utils;
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexMojo.java
@@ -41,11 +41,11 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 import edu.illinois.nondex.common.Configuration;
 import edu.illinois.nondex.common.ConfigurationDefaults;
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.Utils;
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
@@ -30,11 +30,11 @@ package edu.illinois.nondex.plugin;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 import edu.illinois.nondex.common.Configuration;
 import edu.illinois.nondex.common.ConfigurationDefaults;
+import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.Mode;
 import edu.illinois.nondex.common.Utils;


### PR DESCRIPTION
In Java 9+, due to the introduction of the [module system](https://openjdk.java.net/jeps/261), the original logger `java.util.logging` has been separated into an isolated module called `java.logging`. Our experiment indicates that `java.base` can not access any other module or jar during the initialization of boot layer even if we used `—add-reads` option.

We think the usage of class `Level` is minimal so we propose to reimplement the simplified version for the custom `Logger` instead of calling `java.util.logging.Level`.

P.S. Another solution can be using [`java.lang.System.Logger`](https://docs.oracle.com/javase/9/docs/api/java/lang/System.Logger.html) which is designed to log bootstrap information in Java9+.