### PR TITLE
Bump asm.version from 5.1 to 9.0

### DIFF
--- a/nondex-instrumentation/pom.xml
+++ b/nondex-instrumentation/pom.xml
@@ -14,8 +14,13 @@
   <dependencies>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-all</artifactId>
-      <version>5.1</version>
+      <artifactId>asm</artifactId>
+      <version>9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>9.0</version>
     </dependency>
     <dependency>
       <groupId>edu.illinois</groupId>
@@ -39,7 +44,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/ClassVisitorShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/ClassVisitorShufflingAdder.java
@@ -69,7 +69,7 @@ public class ClassVisitorShufflingAdder extends ClassVisitor {
     }
 
     public ClassVisitorShufflingAdder(ClassVisitor ca) {
-        super(Opcodes.ASM5, ca);
+        super(Opcodes.ASM9, ca);
     }
 
     @Override
@@ -87,7 +87,7 @@ public class ClassVisitorShufflingAdder extends ClassVisitor {
 
         if (apisReturningShufflableArrays.contains(methodId)) {
 
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
 
                 @Override
                 public void visitInsn(int opcode) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/ConcurrentHashMapShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/ConcurrentHashMapShufflingAdder.java
@@ -37,14 +37,14 @@ import org.objectweb.asm.Opcodes;
 public class ConcurrentHashMapShufflingAdder extends ClassVisitor {
 
     public ConcurrentHashMapShufflingAdder(ClassVisitor ca) {
-        super(Opcodes.ASM5, ca);
+        super(Opcodes.ASM9, ca);
     }
 
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
                                      String signature, String[] exceptions) {
         if ("<init>".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.RETURN) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/HashMapShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/HashMapShufflingAdder.java
@@ -38,7 +38,7 @@ public class HashMapShufflingAdder extends ClassVisitor {
     private String type;
 
     public HashMapShufflingAdder(ClassVisitor ca, String type) {
-        super(Opcodes.ASM5, ca);
+        super(Opcodes.ASM9, ca);
         this.type = type;
     }
 
@@ -103,7 +103,7 @@ public class HashMapShufflingAdder extends ClassVisitor {
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
         if ("<init>".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.RETURN) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/IdentityHashMapShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/IdentityHashMapShufflingAdder.java
@@ -37,7 +37,7 @@ import org.objectweb.asm.Opcodes;
 public class IdentityHashMapShufflingAdder extends ClassVisitor {
 
     public IdentityHashMapShufflingAdder(ClassVisitor ca) {
-        super(Opcodes.ASM5, ca);
+        super(Opcodes.ASM9, ca);
     }
 
     public void addOrder() {
@@ -181,7 +181,7 @@ public class IdentityHashMapShufflingAdder extends ClassVisitor {
             return super.visitMethod(access, "originalNextIndex", desc, signature, exceptions);
         }
         if ("<init>".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.RETURN) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/MethodShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/MethodShufflingAdder.java
@@ -36,14 +36,14 @@ import org.objectweb.asm.Opcodes;
 public class MethodShufflingAdder extends ClassVisitor {
 
     public MethodShufflingAdder(ClassVisitor ca) {
-        super(Opcodes.ASM5, ca);
+        super(Opcodes.ASM9, ca);
     }
 
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
                                      String signature, String[] exceptions) {
         if ("getExceptionTypes".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.ARETURN) {
@@ -57,7 +57,7 @@ public class MethodShufflingAdder extends ClassVisitor {
             };
         }
         if ("getGenericExceptionTypes".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.ARETURN) {
@@ -71,7 +71,7 @@ public class MethodShufflingAdder extends ClassVisitor {
             };
         }
         if ("getDeclaredAnnotations".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.ARETURN) {
@@ -85,7 +85,7 @@ public class MethodShufflingAdder extends ClassVisitor {
             };
         }
         if ("getParameterAnnotations".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.ARETURN) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/PriorityBlockingQueueShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/PriorityBlockingQueueShufflingAdder.java
@@ -36,7 +36,7 @@ import org.objectweb.asm.Opcodes;
 public class PriorityBlockingQueueShufflingAdder extends ClassVisitor {
 
     public PriorityBlockingQueueShufflingAdder(ClassVisitor ca) {
-        super(Opcodes.ASM5, ca);
+        super(Opcodes.ASM9, ca);
     }
 
     public void addToString() {
@@ -186,7 +186,7 @@ public class PriorityBlockingQueueShufflingAdder extends ClassVisitor {
             return super.visitMethod(access, "originalToString", desc, signature, exceptions);
         }
         if ("toArray".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.ARETURN) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/PriorityQueueShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/PriorityQueueShufflingAdder.java
@@ -37,7 +37,7 @@ import org.objectweb.asm.Opcodes;
 public class PriorityQueueShufflingAdder extends ClassVisitor {
 
     public PriorityQueueShufflingAdder(ClassVisitor ca) {
-        super(Opcodes.ASM5, ca);
+        super(Opcodes.ASM9, ca);
     }
 
     public void addElements() {
@@ -112,7 +112,7 @@ public class PriorityQueueShufflingAdder extends ClassVisitor {
             return super.visitMethod(access, "originalNext", desc, signature, exceptions);
         }
         if ("<init>".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.RETURN) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/WeakHashMapShufflingAdder.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/WeakHashMapShufflingAdder.java
@@ -37,7 +37,7 @@ import org.objectweb.asm.Opcodes;
 public class WeakHashMapShufflingAdder extends ClassVisitor {
 
     public WeakHashMapShufflingAdder(ClassVisitor ca) {
-        super(Opcodes.ASM5, ca);
+        super(Opcodes.ASM9, ca);
     }
 
     public void addIter() {
@@ -112,7 +112,7 @@ public class WeakHashMapShufflingAdder extends ClassVisitor {
             return super.visitMethod(access, "originalNextEntry", desc, signature, exceptions);
         }
         if ("<init>".equals(name)) {
-            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            return new MethodVisitor(Opcodes.ASM9, super.visitMethod(access, name, desc, signature, exceptions)) {
                 @Override
                 public void visitInsn(int opcode) {
                     if (opcode == Opcodes.RETURN) {

--- a/nondex-maven-plugin/pom.xml
+++ b/nondex-maven-plugin/pom.xml
@@ -138,7 +138,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.4</version>
+          <version>3.6.0</version>
           <configuration>
             <goalPrefix>nondex</goalPrefix>
             <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>


### PR DESCRIPTION
Updated asm version to 9.0 because `ASM5` doesn't support Java9 and other later versions. Also updated the versions of `maven-shade-plugin` and `maven-plugin-plugin` to match the change.