### PR TITLE
Refactor Instrumenter to add Java9+ branching

### DIFF
--- a/nondex-common/pom.xml
+++ b/nondex-common/pom.xml
@@ -45,5 +45,35 @@
       </plugin>
     </plugins>
   </build>
-  
+
+  <profiles>
+    <profile>
+      <id>java9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalOptions>--add-exports java.base/jdk.internal.misc=ALL-UNNAMED</additionalOptions>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs>
+                <arg>--add-exports</arg>
+                <arg>java.base/jdk.internal.misc=ALL-UNNAMED</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/nondex-common/src/main/java/edu/illinois/nondex/common/Utils.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/Utils.java
@@ -83,11 +83,15 @@ public class Utils {
         }
     }
 
+    public static boolean checkJDKBefore8() {
+        return System.getProperty("java.version").startsWith("1.");
+    }
+
+    public static boolean checkJDK8() {
+        return System.getProperty("java.version").startsWith("1.8");
+    }
+
     public static Path getRtJarLocation() {
-        if (!System.getProperty("java.version").startsWith("1.8.")) {
-            Logger.getGlobal().log(Level.SEVERE, System.getProperty("java.version"));
-            throw new UnsupportedOperationException("NonDex only supports Java 8");
-        }
         String javaHome = System.getProperty("java.home");
         if (javaHome == null) {
             Logger.getGlobal().log(Level.SEVERE, "JAVA_HOME is not set!");

--- a/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/shuffling/ControlNondeterminism.java
@@ -29,16 +29,17 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package edu.illinois.nondex.shuffling;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 import edu.illinois.nondex.common.Configuration;
 import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.NonDex;
+import edu.illinois.nondex.common.Utils;
 
 public class ControlNondeterminism {
 
@@ -46,10 +47,12 @@ public class ControlNondeterminism {
 
     private static NonDex nondex;
 
+    private static boolean isCreatingNonDex = false;
+
     static {
         // Add shutdown hook
         Runtime.getRuntime().addShutdownHook(ControlNondeterminism.jvmShutdownHook);
-        nondex = new NonDex();
+        initializeNondex();
     }
 
     public static Configuration getConfiguration() {
@@ -60,6 +63,13 @@ public class ControlNondeterminism {
         if (originalOrder.size() < 2) {
             return originalOrder;
         }
+
+        initializeNondex();
+
+        if (nondex == null) {
+            return originalOrder;
+        }
+
         return nondex.getPermutation(originalOrder);
     }
 
@@ -68,6 +78,12 @@ public class ControlNondeterminism {
             return null;
         }
         if (originalOrder.length < 2) {
+            return originalOrder;
+        }
+
+        initializeNondex();
+
+        if (nondex == null) {
             return originalOrder;
         }
 
@@ -95,6 +111,33 @@ public class ControlNondeterminism {
 
     }
 
+    private static void initializeNondex() {
+        // TODO (XLXL) Temporary solution to prevent JVM crash. It's not safe to invoke isBooted()
+        //  or getProperty before saveAndRemoveProperties in System.initPhase1 is done
+        if (System.out == null) {
+            return;
+        }
+
+        if (Utils.checkJDKBefore8()) {
+            if (nondex == null) {
+                nondex = NonDex.getInstance();
+            }
+            return;
+        }
+
+        try {
+            Method isBooted = Class.forName("jdk.internal.misc.VM").getDeclaredMethod("isBooted");
+            if ((Boolean)isBooted.invoke(null) && nondex == null && !isCreatingNonDex) {
+                isCreatingNonDex = true;
+                // Call getStackTrace here to bypass exception "can't initialize class StackTraceElement$HashedModules"
+                Thread.currentThread().getStackTrace();
+                nondex = NonDex.getInstance();
+            }
+        } catch (Exception ex) {
+            Logger.getGlobal().log(Level.INFO,
+                    "Exception when loading jdk.internal.misc.VM with reflection" + ex.getMessage());
+        }
+    }
 
     private static class JVMShutdownHook extends Thread {
         @Override

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/CVFactory.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/CVFactory.java
@@ -29,7 +29,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package edu.illinois.nondex.instr;
 
 import java.security.NoSuchAlgorithmException;
-import java.util.zip.ZipFile;
 
 import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
@@ -37,14 +36,14 @@ import edu.illinois.nondex.common.Logger;
 import org.objectweb.asm.ClassVisitor;
 
 public class CVFactory {
-    public static ClassVisitor construct(ClassVisitor cv, String clzToInstrument, ZipFile rt)
+    public static ClassVisitor construct(ClassVisitor cv, String clzToInstrument)
             throws NoSuchAlgorithmException {
         if (clzToInstrument.equals(Instrumenter.concurrentHashMapName)) {
             return new ConcurrentHashMapShufflingAdder(cv);
         } else if (clzToInstrument.equals(Instrumenter.hashMapName)) {
-            if (rt.getEntry("java/util/HashMap$Node.class") != null) {
+            if (Instrumenter.hasClassEntry(Instrumenter.hashMapNodeName)) {
                 return new HashMapShufflingAdder(cv, "Node");
-            } else if (rt.getEntry("java/util/HashMap$Entry.class") != null) {
+            } else if (Instrumenter.hasClassEntry(Instrumenter.hashMapEntryName)) {
                 return new HashMapShufflingAdder(cv, "Entry");
             }
         } else if (clzToInstrument.equals(Instrumenter.weakHashMapName)) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Main.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Main.java
@@ -33,7 +33,11 @@ import edu.illinois.nondex.common.Utils;
 public class Main {
     public static void main(String...args) throws Exception {
         if (args.length == 1) {
-            Instrumenter.instrument(Utils.getRtJarLocation().toString(), args[0]);
+            String rtPath = "";
+            if (Utils.checkJDK8()) {
+                rtPath = Utils.getRtJarLocation().toString();
+            }
+            Instrumenter.instrument(rtPath, args[0]);
         } else if (args.length == 2) {
             Instrumenter.instrument(args[0], args[1]);
         } else {

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
@@ -158,11 +158,16 @@ public abstract class AbstractNonDexMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Logger.getGlobal().setLoggingLevel(Level.parse(this.loggingLevel));
-        Path rtJarPath;
-        rtJarPath = Utils.getRtJarLocation();
-        if (rtJarPath == null) {
-            Logger.getGlobal().log(Level.SEVERE, "Cannot find the rt.jar!");
-            throw new MojoExecutionException("Cannot find the rt.jar!");
+
+        String rtPathStr = "";
+        if (Utils.checkJDK8()) {
+            Path rtPath;
+            rtPath = Utils.getRtJarLocation();
+            if (rtPath == null) {
+                Logger.getGlobal().log(Level.SEVERE, "Cannot find the rt.jar!");
+                throw new MojoExecutionException("Cannot find the rt.jar!");
+            }
+            rtPathStr = rtPath.toString();
         }
 
         try {
@@ -170,7 +175,7 @@ public abstract class AbstractNonDexMojo extends AbstractMojo {
                     ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR).toFile();
 
             fileForJar.mkdirs();
-            Instrumenter.instrument(rtJarPath.toString(), Paths.get(fileForJar.getAbsolutePath(),
+            Instrumenter.instrument(rtPathStr, Paths.get(fileForJar.getAbsolutePath(),
                     ConfigurationDefaults.INSTRUMENTATION_JAR).toString());
         } catch (IOException exc) {
             exc.printStackTrace();

--- a/nondex-test/pom.xml
+++ b/nondex-test/pom.xml
@@ -102,6 +102,44 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>java8Below</id>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>-Xbootclasspath/p:"${project.basedir}${file.separator}..${file.separator}nondex-instrumentation${file.separator}resources${file.separator}out.jar${path.separator}${project.build.directory}${file.separator}..${file.separator}..${file.separator}nondex-common${file.separator}target${file.separator}classes${file.separator}"</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java9Above</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--add-exports java.base/edu.illinois.nondex.common=ALL-UNNAMED --add-exports java.base/edu.illinois.nondex.shuffling=ALL-UNNAMED --patch-module java.base="${project.basedir}${file.separator}..${file.separator}nondex-instrumentation${file.separator}resources${file.separator}out.jar${path.separator}${project.build.directory}${file.separator}..${file.separator}..${file.separator}nondex-common${file.separator}target${file.separator}classes${file.separator}"</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>edu.illinois</groupId>


### PR DESCRIPTION
* Modified `Instrumenter.java` to support Java9+ version. After Java9, `rt.jar` should be replaced by JRT filesystem to extract runtime classes to be instrumented.
* Add condition check to postpone `NonDex` object initialization in `ControlNondeterminism` after VM is booted in Java9+. (Java9+ changes the implementation in VM.class that loads the instrumented classes `java.util.HashMap/concurrent.ConcurrentHashMap`, which is instrumented by `NonDex`, the accidental order of class loading will crash the JVM and caused `ExceptionInInitializerError` error)
* Add Maven profiles to use different command arglines for Java8/Java9+
* We also did some refactoring work to eliminate duplicate code.