### PR TITLE
performance improvement on hashmap

### DIFF
--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/DebugMojo.java
@@ -78,9 +78,9 @@ public class DebugMojo extends AbstractNonDexMojo {
         }
 
         this.getLog().warn("*********");
-        for (String test : testToRepro.keySet()) {
-            this.getLog().warn("REPRO for " + test + ":" + String.format("%n")
-                               + "mvn nondex:nondex " + testToRepro.get(test));
+        for (Map.Entry<String, String> test : testToRepro.entrySet()) {
+            this.getLog().warn("REPRO for " + test.getKey() + ":" + String.format("%n")
+                               + "mvn nondex:nondex " + test.getValue());
         }
     }
 


### PR DESCRIPTION
Using entrySet instead of keySet, we do not have to access hashmap again to obtain the value. This could be a potential performance improvement for many values that share one hash value.
- The fixing report is generated by Amazon CodeGuru reviewer
- Test cases in nondex-maven-plugin module passed