### PR TITLE
Add support for Java 9+: Addressed code changes in #155 and resolved conflicts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ buildNumber.properties
 .idea/*
 *.iml
 
+### MAC ###
+.DS_Store
+
 ### Emacs ###
 # -*- mode: gitignore; -*-
 *~

--- a/nondex-common/pom.xml
+++ b/nondex-common/pom.xml
@@ -10,6 +10,7 @@
   <artifactId>nondex-common</artifactId>
   <packaging>jar</packaging>
   <name>nondex-common</name>
+
   
   <build>
     <plugins>
@@ -45,5 +46,35 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>java9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalOptions>--add-exports java.base/jdk.internal.misc=ALL-UNNAMED</additionalOptions>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs>
+                <arg>--add-exports</arg>
+                <arg>java.base/jdk.internal.misc=ALL-UNNAMED</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   
 </project>

--- a/nondex-common/src/main/java/edu/illinois/nondex/common/Utils.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/Utils.java
@@ -83,11 +83,15 @@ public class Utils {
         }
     }
 
+    public static boolean checkJDKBefore8() {
+        return System.getProperty("java.version").startsWith("1.");
+    }
+
+    public static boolean checkJDK8() {
+        return System.getProperty("java.version").startsWith("1.8");
+    }
+
     public static Path getRtJarLocation() {
-        if (!System.getProperty("java.version").startsWith("1.8.")) {
-            Logger.getGlobal().log(Level.SEVERE, System.getProperty("java.version"));
-            throw new UnsupportedOperationException("NonDex only supports Java 8");
-        }
         String javaHome = System.getProperty("java.home");
         if (javaHome == null) {
             Logger.getGlobal().log(Level.SEVERE, "JAVA_HOME is not set!");

--- a/nondex-core/pom.xml
+++ b/nondex-core/pom.xml
@@ -17,7 +17,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -40,7 +39,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.6.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/CVFactory.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/CVFactory.java
@@ -29,7 +29,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package edu.illinois.nondex.instr;
 
 import java.security.NoSuchAlgorithmException;
-import java.util.zip.ZipFile;
 
 import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
@@ -37,14 +36,14 @@ import edu.illinois.nondex.common.Logger;
 import org.objectweb.asm.ClassVisitor;
 
 public class CVFactory {
-    public static ClassVisitor construct(ClassVisitor cv, String clzToInstrument, ZipFile rt)
+    public static ClassVisitor construct(ClassVisitor cv, String clzToInstrument)
             throws NoSuchAlgorithmException {
         if (clzToInstrument.equals(Instrumenter.concurrentHashMapName)) {
             return new ConcurrentHashMapShufflingAdder(cv);
         } else if (clzToInstrument.equals(Instrumenter.hashMapName)) {
-            if (rt.getEntry("java/util/HashMap$Node.class") != null) {
+            if (Instrumenter.hasClassEntry(Instrumenter.hashMapNodeName)) {
                 return new HashMapShufflingAdder(cv, "Node");
-            } else if (rt.getEntry("java/util/HashMap$Entry.class") != null) {
+            } else if (Instrumenter.hasClassEntry(Instrumenter.hashMapEntryName)) {
                 return new HashMapShufflingAdder(cv, "Entry");
             }
         } else if (clzToInstrument.equals(Instrumenter.weakHashMapName)) {

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Instrumenter.java
@@ -28,12 +28,17 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package edu.illinois.nondex.instr;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -46,6 +51,7 @@ import java.util.zip.ZipOutputStream;
 
 import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
+import edu.illinois.nondex.common.Utils;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -61,6 +67,15 @@ public final class Instrumenter {
     public static final String methodName = "java/lang/reflect/Method.class";
     public static final String priorityQueueName = "java/util/PriorityQueue$Itr.class";
     public static final String priorityBlockingQueueName = "java/util/concurrent/PriorityBlockingQueue.class";
+
+    public static final String hashMapNodeName = "java/util/HashMap$Node.class";
+    public static final String hashMapEntryName = "java/util/HashMap$Entry.class";
+    public static final String hashMapHashIteratorShufflerName = "java/util/HashMap$HashIterator$HashIteratorShuffler.class";
+
+    private static final String rootPath = "modules/java.base";
+
+    private static FileSystem rtFileSystem = null;
+    private static ZipFile rtZipFile = null;
 
     private final Set<String> standardClassesToInstrument = new HashSet<>();
     private final Set<String> specialClassesToInstrument = new HashSet<>();
@@ -92,21 +107,75 @@ public final class Instrumenter {
     public static final void instrument(String rtJar, String outJar)
             throws NoSuchAlgorithmException, IOException {
         Logger.getGlobal().log(Level.FINE, "Instrumenting " + rtJar + " into " + outJar);
-        new Instrumenter().process(rtJar, outJar);
+        // rt.jar path will not be used in Java9+ environment
+        new Instrumenter().initAndProcess(rtJar, outJar);
     }
 
-    private void process(String rtJar, String outJar)
-            throws IOException, NoSuchAlgorithmException, FileNotFoundException {
-        ZipFile rt = null;
-        try {
-            rt = new ZipFile(rtJar);
-        } catch (IOException exc) {
-            Logger.getGlobal().log(Level.SEVERE, "Are you sure you provided a valid path to your rt.jar?");
-            throw exc;
+    private InputStream getClassInputStream(String className)
+            throws IOException {
+        InputStream clInputStream;
+        if (rtZipFile != null) {
+            try {
+                ZipEntry entry = rtZipFile.getEntry(className);
+                if (entry == null) {
+                    Logger.getGlobal().log(Level.WARNING, "Could not find " + className + " in rt.jar");
+                    Logger.getGlobal().log(Level.WARNING, "Are you running java 8?");
+                    Logger.getGlobal().log(Level.WARNING, "Continuing without instrumenting: " + className);
+                    return null;
+                }
+                clInputStream = rtZipFile.getInputStream(entry);
+                return clInputStream;
+            } catch (IOException exc) {
+                Logger.getGlobal().log(Level.WARNING, "Cannot find " + className + " are you sure this is a valid rt.jar?");
+                Logger.getGlobal().log(Level.WARNING, "Continuing without instrumenting: " + className);
+            }
         }
-        final Set<String> classesToCopy = this.filterCached(rt, outJar);
 
-        // If no class needs to be reinsturmented
+        if (rtFileSystem != null) {
+            try {
+                Path curClsPath = rtFileSystem.getPath(rootPath, className);
+                byte[] clsBytes = Files.readAllBytes(curClsPath);
+                return new ByteArrayInputStream(clsBytes);
+            } catch (IOException exc) {
+                Logger.getGlobal().log(Level.WARNING, "Could not find " + className + " in jrt file system");
+                Logger.getGlobal().log(Level.WARNING, "Continuing without instrumenting: " + className);
+            }
+        }
+        return null;
+    }
+
+    static boolean hasClassEntry(String className) {
+        if (rtZipFile != null) {
+            return rtZipFile.getEntry(className) != null;
+        } else {
+            Path curClsPath = rtFileSystem.getPath(rootPath, className);
+            return Files.exists(curClsPath);
+        }
+    }
+
+    private void initAndProcess(String rtPath, String outJar)
+            throws IOException, NoSuchAlgorithmException {
+        if (Utils.checkJDKBefore8()) {
+            ZipFile rt = null;
+            try {
+                rt = new ZipFile(rtPath);
+            } catch (IOException exc) {
+                Logger.getGlobal().log(Level.SEVERE, "Are you sure you provided a valid path to your rt.jar?");
+                throw exc;
+            }
+            rtZipFile = rt;
+        } else {
+            rtFileSystem = FileSystems.getFileSystem(URI.create("jrt:/"));
+        }
+        this.process(outJar);
+    }
+
+    private void process(String outJar)
+            throws IOException, NoSuchAlgorithmException {
+
+        final Set<String> classesToCopy = this.filterCached(outJar);
+
+        // If no class needs to be re-instrumented
         if (this.standardClassesToInstrument.isEmpty() && this.specialClassesToInstrument.isEmpty()) {
             return;
         }
@@ -114,18 +183,18 @@ public final class Instrumenter {
         ByteArrayOutputStream outZipBaos = new ByteArrayOutputStream();
         ZipOutputStream outZip = new ZipOutputStream(outZipBaos);
 
-        this.instrumentStandardClasses(rt, outZip);
+        this.instrumentStandardClasses(outZip);
 
-        if (rt.getEntry("java/util/HashMap$Node.class") != null) {
-            this.addAsmDumpResultToZip(outZip, "java/util/HashMap$HashIterator$HashIteratorShuffler.class",
+        if (Instrumenter.hasClassEntry(hashMapNodeName)) {
+            this.addAsmDumpResultToZip(outZip, hashMapHashIteratorShufflerName,
                     new Producer<byte[]>() {
                         @Override
                         public byte[] apply() {
                             return HashIteratorShufflerASMDump.dump("Node");
                         }
                     });
-        } else if (rt.getEntry("java/util/HashMap$Entry.class") != null) {
-            this.addAsmDumpResultToZip(outZip, "java/util/HashMap$HashIterator$HashIteratorShuffler.class",
+        } else if (Instrumenter.hasClassEntry(hashMapEntryName)) {
+            this.addAsmDumpResultToZip(outZip, hashMapHashIteratorShufflerName,
                     new Producer<byte[]>() {
                         @Override
                         public byte[] apply() {
@@ -135,7 +204,7 @@ public final class Instrumenter {
         }
 
         for (String clz : this.specialClassesToInstrument) {
-            this.instrumentSpecialClass(rt, outZip, clz);
+            this.instrumentSpecialClass(outZip, clz);
         }
 
         this.copyCachedClassesToOutZip(outJar, classesToCopy, outZip);
@@ -146,32 +215,16 @@ public final class Instrumenter {
         fos.close();
     }
 
-
-    private void instrumentStandardClasses(ZipFile rt, ZipOutputStream outZip)
+    private void instrumentStandardClasses(ZipOutputStream outZip)
             throws IOException, NoSuchAlgorithmException {
         for (String cl : this.standardClassesToInstrument) {
-            InputStream clInputStream = null;
-            try {
-                ZipEntry entry = rt.getEntry(cl);
-                if (entry == null) {
-                    Logger.getGlobal().log(Level.WARNING, "Could not find " + cl + " in rt.jar");
-                    Logger.getGlobal().log(Level.WARNING, "Are you running java 8?");
-                    Logger.getGlobal().log(Level.WARNING, "Continuing without instrumenting: " + cl);
-
-                    continue;
-                }
-                clInputStream = rt.getInputStream(entry);
-            } catch (IOException exc) {
-                // I am not sure this code is reachable
-                // TODO(gyori): Test that this code is reachable;
-                Logger.getGlobal().log(Level.WARNING, "Cannot find " + cl + " are you sure this is a valid rt.jar?");
-                Logger.getGlobal().log(Level.WARNING, "Continuing without insturmenting: " + cl);
+            InputStream clInputStream = this.getClassInputStream(cl);
+            if (clInputStream == null) {
                 continue;
             }
-
             this.writeMd5(clInputStream, cl + ".md5", outZip);
 
-            clInputStream = rt.getInputStream(rt.getEntry(cl));
+            clInputStream = this.getClassInputStream(cl);
 
             ClassReader cr = new ClassReader(clInputStream);
             ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
@@ -212,8 +265,7 @@ public final class Instrumenter {
     private void writeMd5(InputStream isToComputeHashOn, String fileName, ZipOutputStream zip)
             throws IOException, NoSuchAlgorithmException {
         if (isToComputeHashOn == null) {
-            Logger.getGlobal().log(Level.WARNING, "Could not find " + fileName + " in rt.jar");
-            Logger.getGlobal().log(Level.WARNING, "Are you running java 8?");
+            Logger.getGlobal().log(Level.WARNING, "Could not find " + fileName + " inputStream");
             Logger.getGlobal().log(Level.WARNING, "Continuing without instrumenting: " + fileName);
             return;
         }
@@ -227,14 +279,11 @@ public final class Instrumenter {
 
 
     private void instrumentClass(String className,
-                                        Function<ClassVisitor, ClassVisitor> createShuffler,
-                                        ZipFile rt, ZipOutputStream outZip) throws IOException {
-        InputStream classStream = null;
-        try {
-            classStream = rt.getInputStream(rt.getEntry(className));
-        } catch (IOException exc) {
-            Logger.getGlobal().log(Level.WARNING, "Cannot find " + className + " are you sure this is a valid rt.jar?");
-            Logger.getGlobal().log(Level.WARNING, "Continuing without instrumenting: " + className);
+                                 Function<ClassVisitor, ClassVisitor> createShuffler,
+                                 ZipOutputStream outZip) throws IOException {
+        InputStream classStream = this.getClassInputStream(className);
+        if (classStream == null) {
+            return;
         }
         ClassReader cr = new ClassReader(classStream);
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
@@ -252,20 +301,16 @@ public final class Instrumenter {
         outZip.closeEntry();
     }
 
-    private Set<String> removeCachedFromShufflingList(Set<String> toShuffle, ZipFile rt, ZipFile outJarZipFile)
+    private Set<String> removeCachedFromShufflingList(Set<String> toShuffle, ZipFile outJarZipFile)
             throws IOException, NoSuchAlgorithmException {
         Set<String> toCopy = new HashSet<String>();
         Iterator<String> it = toShuffle.iterator();
         while (it.hasNext()) {
             String cl = it.next();
 
-            ZipEntry entry = rt.getEntry(cl);
-            if (entry == null) {
-                continue;
-            }
-            InputStream clInputStream = rt.getInputStream(entry);
+            InputStream clInputStream = this.getClassInputStream(cl);
 
-            entry = outJarZipFile.getEntry(cl + ".md5");
+            ZipEntry entry = outJarZipFile.getEntry(cl + ".md5");
             if (entry == null) {
                 continue;
             }
@@ -279,39 +324,35 @@ public final class Instrumenter {
         return toCopy;
     }
 
-    private Set<String> filterCached(ZipFile rt, String oldJar) throws IOException, NoSuchAlgorithmException {
+    /*
+        Get a set of classes to be instrumented if out.jar exists
+    */
+    private Set<String> filterCached(String oldJar) throws IOException, NoSuchAlgorithmException {
         Set<String> classesToCopy = new HashSet<>();
         if (new File(oldJar).exists()) {
             ZipFile outJarZipFile = new ZipFile(oldJar);
             classesToCopy.addAll(this.removeCachedFromShufflingList(this.standardClassesToInstrument,
-                    rt, outJarZipFile));
+                    outJarZipFile));
             classesToCopy.addAll(this.removeCachedFromShufflingList(this.specialClassesToInstrument,
-                    rt, outJarZipFile));
+                    outJarZipFile));
         }
         return classesToCopy;
     }
 
-    private <T extends CVFactory> void instrumentSpecialClass(final ZipFile rt, ZipOutputStream outZip, final String clz)
+    private <T extends CVFactory> void instrumentSpecialClass(ZipOutputStream outZip, final String clz)
             throws IOException, NoSuchAlgorithmException {
-        ZipEntry entry = rt.getEntry(clz);
-        if (entry == null) {
-            Logger.getGlobal().log(Level.WARNING, "Could not find " + clz + " in rt.jar");
-            Logger.getGlobal().log(Level.WARNING, "Are you sure you're running java 8?");
-            Logger.getGlobal().log(Level.WARNING, "Continuing without instrumenting: " + clz);
-            return;
-        }
-        this.writeMd5(rt.getInputStream(rt.getEntry(clz)), clz + ".md5", outZip);
+        this.writeMd5(this.getClassInputStream(clz), clz + ".md5", outZip);
         this.instrumentClass(clz,
                 new Function<ClassVisitor, ClassVisitor>() {
                     @Override
                     public ClassVisitor apply(ClassVisitor cv) {
                         try {
-                            return CVFactory.construct(cv, clz, rt);
+                            return CVFactory.construct(cv, clz);
                         } catch (NoSuchAlgorithmException nsaException) {
                             return null;
                         }
                     }
-                }, rt, outZip);
+                }, outZip);
     }
 
     private void addAsmDumpResultToZip(ZipOutputStream outZip, String entryName, Producer<byte[]> classProducer)

--- a/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Main.java
+++ b/nondex-instrumentation/src/main/java/edu/illinois/nondex/instr/Main.java
@@ -33,7 +33,11 @@ import edu.illinois.nondex.common.Utils;
 public class Main {
     public static void main(String...args) throws Exception {
         if (args.length == 1) {
-            Instrumenter.instrument(Utils.getRtJarLocation().toString(), args[0]);
+            String rtPath = "";
+            if (Utils.checkJDK8()) {
+                rtPath = Utils.getRtJarLocation().toString();
+            }
+            Instrumenter.instrument(rtPath, args[0]);
         } else if (args.length == 2) {
             Instrumenter.instrument(args[0], args[1]);
         } else {

--- a/nondex-instrumentation/src/test/java/edu/illinois/nondex/instr/InstrumenterTest.java
+++ b/nondex-instrumentation/src/test/java/edu/illinois/nondex/instr/InstrumenterTest.java
@@ -40,7 +40,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 
+import edu.illinois.nondex.common.Utils;
+
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,6 +63,7 @@ public class InstrumenterTest {
 
     @Test
     public void emptyZipTest() throws NoSuchAlgorithmException, IOException {
+        Assume.assumeTrue(Utils.checkJDKBefore8());
         Instrumenter.instrument(Paths.get("resources", "empty.jar").toString(),
                                 outJar.toString());
         assertTrue(Files.exists(outJar, LinkOption.NOFOLLOW_LINKS));
@@ -67,6 +71,7 @@ public class InstrumenterTest {
 
     @Test
     public void nonexistantZipTest() throws NoSuchAlgorithmException {
+        Assume.assumeTrue(Utils.checkJDKBefore8());
         try {
             Instrumenter.instrument(Paths.get("resources", "doesnotexist.jar").toString(),
                                     Paths.get("resources", "doesnotexistOut.jar").toString());

--- a/nondex-maven-plugin/src/it/clean-it with-whitespace-in-path/pom.xml
+++ b/nondex-maven-plugin/src/it/clean-it with-whitespace-in-path/pom.xml
@@ -16,6 +16,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
         <version>@project.version@</version>
@@ -23,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.2</version>
       </plugin>
     </plugins>
   </build>

--- a/nondex-maven-plugin/src/it/clean-it/pom.xml
+++ b/nondex-maven-plugin/src/it/clean-it/pom.xml
@@ -16,6 +16,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
         <version>@project.version@</version>
@@ -23,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.2</version>
       </plugin>
     </plugins>
   </build>

--- a/nondex-maven-plugin/src/it/comprehensive/pom.xml
+++ b/nondex-maven-plugin/src/it/comprehensive/pom.xml
@@ -18,7 +18,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -32,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.2</version>
         <configuration>
           <rerunFailingTestsCount>2</rerunFailingTestsCount>
         </configuration>

--- a/nondex-maven-plugin/src/it/excluded-groups-it/module1/pom.xml
+++ b/nondex-maven-plugin/src/it/excluded-groups-it/module1/pom.xml
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.2</version>
                 <configuration>
                     <excludedGroups>edu.illinois.nondex.it.Module1Ignore</excludedGroups>
                 </configuration>

--- a/nondex-maven-plugin/src/it/excluded-groups-it/pom.xml
+++ b/nondex-maven-plugin/src/it/excluded-groups-it/pom.xml
@@ -19,22 +19,30 @@
     </modules>
 
     <build>
-      <plugins>
-	<plugin>
-	  <groupId>@project.groupId@</groupId>
-          <artifactId>nondex-maven-plugin</artifactId>
-          <version>@project.version@</version>
-	</plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
-          <configuration>
-            <rerunFailingTestsCount>2</rerunFailingTestsCount>
-          </configuration>
-	</plugin>
-      </plugins>
-
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>nondex-maven-plugin</artifactId>
+                <version>@project.version@</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
     
     <dependencies>

--- a/nondex-maven-plugin/src/it/failing-it/pom.xml
+++ b/nondex-maven-plugin/src/it/failing-it/pom.xml
@@ -16,6 +16,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
         <version>@project.version@</version>
@@ -23,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.2</version>
       </plugin>
     </plugins>
   </build>

--- a/nondex-maven-plugin/src/it/inexistent-variable-argline-it/pom.xml
+++ b/nondex-maven-plugin/src/it/inexistent-variable-argline-it/pom.xml
@@ -17,6 +17,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
         <version>@project.version@</version>
@@ -24,7 +33,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.2</version>
 	<configuration>
 	  <argLine>${some-nonexistent-argline} -DmyArgumentForTesting=1219 ${some.stuff} ${some.existing} ${An0ther-st.uff}</argLine>
 	</configuration>

--- a/nondex-maven-plugin/src/it/simple-it/pom.xml
+++ b/nondex-maven-plugin/src/it/simple-it/pom.xml
@@ -16,6 +16,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
         <version>@project.version@</version>
@@ -23,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.2</version>
       </plugin>
     </plugins>
   </build>

--- a/nondex-maven-plugin/src/it/simple-multimodule-it/pom.xml
+++ b/nondex-maven-plugin/src/it/simple-multimodule-it/pom.xml
@@ -1,49 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>nondex.plugin.it</groupId>
-    <artifactId>excluded-groups-it</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <description>IT verifying excluded groups</description>
+  <groupId>nondex.plugin.it</groupId>
+  <artifactId>excluded-groups-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <description>IT verifying excluded groups</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
-    <modules>
-      <module>module1</module>
-      <module>module2</module>
-    </modules>
+  <modules>
+    <module>module1</module>
+    <module>module2</module>
+  </modules>
 
-    <build>
-      <plugins>
-	<plugin>
-	  <groupId>@project.groupId@</groupId>
-          <artifactId>nondex-maven-plugin</artifactId>
-          <version>@project.version@</version>
-	</plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
-          <configuration>
-	    <argLine>-DmyArgumentForTesting=1219</argLine>
-            <rerunFailingTestsCount>2</rerunFailingTestsCount>
-          </configuration>
-	</plugin>
-      </plugins>
-    </build>
-    
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nondex-maven-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+        <configuration>
+          <argLine>-DmyArgumentForTesting=1219</argLine>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
@@ -158,11 +158,15 @@ public abstract class AbstractNonDexMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Logger.getGlobal().setLoggingLevel(Level.parse(this.loggingLevel));
-        Path rtJarPath;
-        rtJarPath = Utils.getRtJarLocation();
-        if (rtJarPath == null) {
-            Logger.getGlobal().log(Level.SEVERE, "Cannot find the rt.jar!");
-            throw new MojoExecutionException("Cannot find the rt.jar!");
+        String rtPathStr = "";
+        if (Utils.checkJDK8()) {
+            Path rtPath;
+            rtPath = Utils.getRtJarLocation();
+            if (rtPath == null) {
+                Logger.getGlobal().log(Level.SEVERE, "Cannot find the rt.jar!");
+                throw new MojoExecutionException("Cannot find the rt.jar!");
+            }
+            rtPathStr = rtPath.toString();
         }
 
         try {
@@ -170,18 +174,18 @@ public abstract class AbstractNonDexMojo extends AbstractMojo {
                     ConfigurationDefaults.DEFAULT_NONDEX_JAR_DIR).toFile();
 
             fileForJar.mkdirs();
-            Instrumenter.instrument(rtJarPath.toString(), Paths.get(fileForJar.getAbsolutePath(),
+            Instrumenter.instrument(rtPathStr, Paths.get(fileForJar.getAbsolutePath(),
                     ConfigurationDefaults.INSTRUMENTATION_JAR).toString());
-        } catch (IOException exc) {
-            exc.printStackTrace();
-        } catch (NoSuchAlgorithmException exc) {
+        } catch (IOException | NoSuchAlgorithmException exc) {
             exc.printStackTrace();
         }
 
         this.surefire = this.lookupPlugin("org.apache.maven.plugins:maven-surefire-plugin");
 
         if (this.surefire == null) {
-            Logger.getGlobal().log(Level.SEVERE, "Make sure surefire is in your pom.xml");
+            Logger.getGlobal().log(Level.SEVERE, "Surefire is not explicitly declared in your pom.xml; "
+                    + "we will use version 2.20, but you may want to change that.");
+            this.surefire = getSureFirePlugin();
         }
 
         Properties localProperties = this.mavenProject.getProperties();
@@ -198,5 +202,13 @@ public abstract class AbstractNonDexMojo extends AbstractMojo {
             }
         }
         return null;
+    }
+
+    private Plugin getSureFirePlugin() {
+        Plugin surefire = new Plugin();
+        surefire.setGroupId("org.apache.maven.plugins");
+        surefire.setArtifactId("maven-surefire-plugin");
+        surefire.setVersion("2.20");
+        return surefire;
     }
 }

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexSurefireExecution.java
@@ -84,7 +84,15 @@ public class NonDexSurefireExecution extends CleanSurefireExecution {
             }
             configElement.getChild("test").setValue(this.configuration.testName);
         }
-        String argLineToSet = "" + "-Xbootclasspath/p:" + pathToNondex + File.pathSeparator
+
+        String argLineToSetPrefix = "" + "-Xbootclasspath/p:";
+        if (!Utils.checkJDKBefore8()) {
+            argLineToSetPrefix = "" + "--add-exports java.base/edu.illinois.nondex.common=ALL-UNNAMED "
+                    + "--add-exports java.base/edu.illinois.nondex.shuffling=ALL-UNNAMED "
+                    + " --patch-module " + "java.base=";
+        }
+
+        String argLineToSet = argLineToSetPrefix + pathToNondex + File.pathSeparator
                 + Paths.get(mavenSession.getLocalRepository().getBasedir(),
                         "edu", "illinois", annotationsModuleName, ConfigurationDefaults.VERSION,
                         annotationsModuleName + "-" + ConfigurationDefaults.VERSION + ".jar")

--- a/nondex-test/pom.xml
+++ b/nondex-test/pom.xml
@@ -12,6 +12,43 @@
   <packaging>jar</packaging>
   <name>nondex-test</name>
 
+  <profiles>
+    <profile>
+      <id>java8Below</id>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>-Xbootclasspath/p:"${project.basedir}${file.separator}..${file.separator}nondex-instrumentation${file.separator}resources${file.separator}out.jar${path.separator}${project.build.directory}${file.separator}..${file.separator}..${file.separator}nondex-common${file.separator}target${file.separator}classes${file.separator}"</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java9Above</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--add-exports java.base/edu.illinois.nondex.common=ALL-UNNAMED --add-exports java.base/edu.illinois.nondex.shuffling=ALL-UNNAMED --patch-module java.base="${project.basedir}${file.separator}..${file.separator}nondex-instrumentation${file.separator}resources${file.separator}out.jar${path.separator}${project.build.directory}${file.separator}..${file.separator}..${file.separator}nondex-common${file.separator}target${file.separator}classes${file.separator}"</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
@@ -55,7 +92,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.6.0</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
@@ -68,7 +105,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -89,11 +126,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <argLine>-Xbootclasspath/p:"${project.basedir}${file.separator}..${file.separator}nondex-instrumentation${file.separator}resources${file.separator}out.jar${path.separator}${project.build.directory}${file.separator}..${file.separator}..${file.separator}nondex-common${file.separator}target${file.separator}classes${file.separator}"</argLine>
           <systemPropertyVariables>
             <buildDirectory>${project.build.directory}</buildDirectory>
           </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -158,16 +158,16 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.8.1</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>${java.specification.version}</source>
+            <target>${java.specification.version}</target>
           </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.22.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -197,6 +197,11 @@
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
In recent tests with Java 9/10/11/17 with all code changes in https://github.com/TestingResearchIllinois/NonDex/pull/155, no problems are found. This PR addresses the changes in https://github.com/TestingResearchIllinois/NonDex/pull/155, and makes minor changes to resolve its conflicts with the current main branch.

After this PR NonDex Maven plugin (1.1.3-SNAPSHOT) shall work with both Java 8 and Java 9+.