### PR TITLE
Allowing customizing number of clean NonDex runs in command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ To find if you have flaky tests, run:
 
     mvn nondex:nondex
 
+Notice that NonDex executes 1 clean run (without shuffling) by default. It reports a test if it passes in the clean run and fails in one of the shuffled runs. In this way, some reported tests may be nondeterministic (e.g. fails by chance without NonDex shuffling) or non-idempotent (e.g. silently changes an external field, and can fail even in a second `mvn test -Dtest=...` run), rather than actually making wrong assumptions on under-determined Java APIs. To avoid this, one can specify the number of clean runs (where `i` is the number of clean runs):
+
+    mvn nondex:nondex -DnondexRunsWithoutShuffling=i
+
 To debug, run:
 
     mvn nondex:debug

--- a/nondex-common/src/main/java/edu/illinois/nondex/common/ConfigurationDefaults.java
+++ b/nondex-common/src/main/java/edu/illinois/nondex/common/ConfigurationDefaults.java
@@ -49,6 +49,11 @@ public class ConfigurationDefaults {
     public static final String DEFAULT_NUM_RUNS_STR = "3";
     public static final int DEFAULT_NUM_RUNS = new Integer(ConfigurationDefaults.DEFAULT_NUM_RUNS_STR);
 
+    public static final String PROPERTY_NUM_RUNS_WITHOUT_SHUFFLING = "nondexRunsWithoutShuffling";
+    public static final String DEFAULT_NUM_RUNS_WITHOUT_SHUFFLING_STR = "1";
+    public static final int DEFAULT_NUM_RUNS_WITHOUT_SHUFFLING =
+                        new Integer(ConfigurationDefaults.DEFAULT_NUM_RUNS_WITHOUT_SHUFFLING_STR);
+
     public static final String PROPERTY_FILTER = "nondexFilter";
     public static final String DEFAULT_FILTER = ".*";
 

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
@@ -99,6 +99,13 @@ public abstract class AbstractNonDexMojo extends AbstractMojo {
     @Parameter(property = ConfigurationDefaults.PROPERTY_END, defaultValue = ConfigurationDefaults.DEFAULT_END_STR)
     protected long end;
 
+    /**
+     * The number of clean test runs without NonDex shuffling.
+     * This feature may find if tests are flaky (NOD / NIO) by themselves.
+     */
+    @Parameter(property = ConfigurationDefaults.PROPERTY_NUM_RUNS_WITHOUT_SHUFFLING,
+            defaultValue = ConfigurationDefaults.DEFAULT_NUM_RUNS_WITHOUT_SHUFFLING_STR)
+    protected int numRunsWithoutShuffling;
 
     /**
      * The number of seeds to use for shuffle. NonDex will obtain other seeds

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/AbstractNonDexMojo.java
@@ -101,7 +101,7 @@ public abstract class AbstractNonDexMojo extends AbstractMojo {
 
     /**
      * The number of clean test runs without NonDex shuffling.
-     * This feature may find if tests are flaky (NOD / NIO) by themselves.
+     * This feature may be useful if tests are flaky (NOD / NIO) by themselves.
      */
     @Parameter(property = ConfigurationDefaults.PROPERTY_NUM_RUNS_WITHOUT_SHUFFLING,
             defaultValue = ConfigurationDefaults.DEFAULT_NUM_RUNS_WITHOUT_SHUFFLING_STR)

--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexMojo.java
@@ -180,7 +180,7 @@ public class NonDexMojo extends AbstractNonDexMojo {
             this.getLog().info("All tests pass without NonDex shuffling");
         }
         this.getLog().info("####################");
-        this.getLog().info("Across all seeds (Possible implementation-dependent flaky tests):");
+        this.getLog().info("Across all seeds:");
         for (String test : allFailures) {
             this.getLog().info(test);
         }


### PR DESCRIPTION
Currently, NonDex executes one single clean run before shuffled runs. Then, it reports a test as flaky if it passes in the clean run and fails in one of the shuffled runs. However, in practice there are many ND (e.g. a test with timeout assertion that fails occasionally) / NIO tests (e.g. a test that silently changes some external states such that it fails in the second consecutive `mvn -test` run) falsely reported as ID in this way. 
This PR allows users to manually set the number of clean NonDex runs in command line. NonDex will print out a summary of the clean runs (e.g. "SomeTest" fails in 1/7 clean runs), and exclude all tests that fail in clean runs from the final report "Across all seeds: xxx". Users can use this feature to verify whether a flaky test is really ID.

Sample output on a dummy repo with 2 ND tests written by my own:
```
[INFO] *********
[INFO] In run #1 without NonDex shuffling, no tests failed.
[INFO] ------------------
[INFO] In run #2 without NonDex shuffling, following tests failed:
[WARNING] dummyTestSet#dummyTest1
[WARNING] dummyTestSet#dummyTest2
[INFO] ------------------
[INFO] Following tests are failing in clean runs without NonDex shuffling
[INFO] Check if they are always failing, nondeterministic, or non-idempotent
[INFO] Test: dummyTestSet#dummyTest1
[INFO] Fails in 1 out of 2 clean runs.
[INFO] Test: dummyTestSet#dummyTest2
[INFO] Fails in 1 out of 2 clean runs.
[INFO] ####################
[INFO] Across all seeds:
[INFO] None
```