### PR TITLE
Ensure Sanity for Sonatype checks

### DIFF
--- a/nondex-test/pom.xml
+++ b/nondex-test/pom.xml
@@ -15,6 +15,9 @@
     <profile>
       <id>java8Below</id>
       <activation>
+        <property>
+          <name>!deploy</name>
+        </property>
         <jdk>(,1.8]</jdk>
       </activation>
       <build>
@@ -51,11 +54,52 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>sources-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>2.8.2</version>
         <configuration>
           <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>


### PR DESCRIPTION
This PR addressed the code changes for sanity w.r.t. Maven Central Deployment. It is also the last PR for NonDex 2.1. It does the followings:
1. Version 1.6.7 of `nexus-staging-maven-plugin` is deprecated and causes failures in deploying. Bump the version to 1.6.13.
2. If we use the `mvn deploy -P` scheme (rather than `mvn release:prepare` and `mvn release:perform`), we need to also configure `org.sonatype.plugins` (rather than just `maven-deploy-plugin`) to skip deployment, or that the integration test module will still be deployed.
3. Sonatype enables a scheme to ensure a source code `.jar` file and a Javadoc `.jar` file presented in all submodules. However, as our test module has no `src/main` folder, such jars are not generated, and sanity check fails. The Sonatype maintainers suggest us to generate these empty jars manually, so we used `maven-jar-plugin` to do so.