### PR TITLE
Update Gradle plugin & reflect changes in Maven plugin in preparation for v2.1.1

### DIFF
--- a/nondex-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/nondex-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/nondex-gradle-plugin/plugin/build.gradle
+++ b/nondex-gradle-plugin/plugin/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id 'groovy'
     id 'java-gradle-plugin'
-    id "com.gradle.plugin-publish" version "1.2.1"
+    id "com.gradle.plugin-publish" version "1.3.0"
 }
 
 group = "edu.illinois"
-version = "2.1.7"
+version = "2.2.1"
 
 repositories {
     mavenCentral()

--- a/nondex-gradle-plugin/plugin/src/functionalTest/resources/comprehensive-it/build.gradle
+++ b/nondex-gradle-plugin/plugin/src/functionalTest/resources/comprehensive-it/build.gradle
@@ -9,6 +9,6 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'edu.illinois:nondex-common:2.1.7'
+    testImplementation 'edu.illinois:nondex-common:2.2.1'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/nondex-gradle-plugin/plugin/src/main/java/edu/illinois/nondex/gradle/constants/NonDexGradlePluginConstants.java
+++ b/nondex-gradle-plugin/plugin/src/main/java/edu/illinois/nondex/gradle/constants/NonDexGradlePluginConstants.java
@@ -1,7 +1,14 @@
 package edu.illinois.nondex.gradle.constants;
 
+import edu.illinois.nondex.gradle.util.MavenChecksumFetcher;
+
 public abstract class NonDexGradlePluginConstants {
 
-    public static final String NONDEX_VERSION = "2.1.7";
-    public static final String NONDEX_COMMON_SHA1 = "70dd8887de7a6c46863eca52f1809ed73274d90e";
+    public static final String NONDEX_VERSION = "2.2.1";
+    public static final String NONDEX_COMMON_SHA1 = MavenChecksumFetcher.getSHA1(
+        "edu.illinois",
+        "nondex-common",
+        NONDEX_VERSION
+    );
+    
 }

--- a/nondex-gradle-plugin/plugin/src/main/java/edu/illinois/nondex/gradle/util/MavenChecksumFetcher.java
+++ b/nondex-gradle-plugin/plugin/src/main/java/edu/illinois/nondex/gradle/util/MavenChecksumFetcher.java
@@ -1,0 +1,40 @@
+package edu.illinois.nondex.gradle.util;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class MavenChecksumFetcher {
+
+    /**
+     * Fetches the SHA1 checksum of a JAR file from Maven Central repository.
+     *
+     * This method constructs the URL to the checksum file for a given artifact based on its
+     * groupId, artifactId, and version, then makes an HTTP GET request to fetch the SHA1 checksum.
+     * It returns the SHA1 checksum as a string.
+     *
+     * @param groupId     The group ID of the artifact (e.g., "edu.illinois")
+     * @param artifactId  The artifact ID of the artifact (e.g., "nondex-common")
+     * @param version     The version of the artifact (e.g., "2.2.1")
+     * @return            The SHA1 checksum of the artifact as a string
+     */
+    public static String getSHA1(String groupId, String artifactId, String version) {
+        try {
+            String baseUrl = "https://repo1.maven.org/maven2/";
+            String sha1Url = baseUrl + groupId.replace(".", "/") + "/" + artifactId + "/" + version + "/" 
+                            + artifactId + "-" + version + ".jar.sha1";
+
+            URL url = new URL(sha1Url);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+                return reader.readLine(); // Returns the SHA1 checksum
+            }
+        } catch (Exception e) {
+            return null;
+        }   
+    }
+    
+}


### PR DESCRIPTION
Changes:
1. Add a checksum checker to get the SHA1 (to locate the downloaded nondex-common jar) instead of hard-coding it.
2. Duplicate the change for Maven (#193)  in resolving the JVM crashing issue
3. Version bumps to support the latest Gradle version, 8.11.1